### PR TITLE
feat(domain): add Weight VO and refactor tests to table-driven

### DIFF
--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrPasswordTooShort    = errors.New("password must be at least 8 characters")
 	ErrNicknameRequired    = errors.New("nickname is required")
 	ErrNicknameTooLong     = errors.New("nickname must be 50 characters or less")
+	ErrWeightMustBePositive = errors.New("weight must be positive")
+	ErrWeightTooHeavy       = errors.New("weight must be 500kg or less")
 )

--- a/backend/domain/vo/email_test.go
+++ b/backend/domain/vo/email_test.go
@@ -8,124 +8,68 @@ import (
 	"caltrack/domain/vo"
 )
 
-func TestNewEmail_ValidEmail_ReturnsEmail(t *testing.T) {
-	email, err := vo.NewEmail("user@example.com")
+func TestNewEmail(t *testing.T) {
+	// 境界値テスト用の長いメール作成
+	local64 := strings.Repeat("a", 64)
+	domain185 := strings.Repeat("b", 185) + ".com" // 254 - 64 - 1(@) - 4(.com) = 185
+	email254 := local64 + "@" + domain185
+	domain186 := strings.Repeat("b", 186) + ".com"
+	email255 := local64 + "@" + domain186
 
-	if err != nil {
-		t.Errorf("NewEmail should not return error for valid email, got: %v", err)
+	tests := []struct {
+		name      string
+		input     string
+		wantEmail string
+		wantErr   error
+	}{
+		// 正常系
+		{"valid email", "user@example.com", "user@example.com", nil},
+		{"valid email with subdomain", "user@mail.example.com", "user@mail.example.com", nil},
+		{"valid email with plus", "user+tag@example.com", "user+tag@example.com", nil},
+		// 異常系
+		{"empty string", "", "", domainErrors.ErrEmailRequired},
+		{"no at sign", "userexample.com", "", domainErrors.ErrInvalidEmailFormat},
+		{"no domain", "user@", "", domainErrors.ErrInvalidEmailFormat},
+		{"no local part", "@example.com", "", domainErrors.ErrInvalidEmailFormat},
+		// 境界値
+		{"max length 254", email254, email254, nil},
+		{"exceeds 254", email255, "", domainErrors.ErrEmailTooLong},
 	}
-	if email.String() != "user@example.com" {
-		t.Errorf("Email.String() should return the email, got: %s", email.String())
-	}
-}
 
-func TestNewEmail_ValidEmailWithSubdomain_ReturnsEmail(t *testing.T) {
-	email, err := vo.NewEmail("user@mail.example.com")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vo.NewEmail(tt.input)
 
-	if err != nil {
-		t.Errorf("NewEmail should not return error for valid email with subdomain, got: %v", err)
-	}
-	if email.String() != "user@mail.example.com" {
-		t.Errorf("Email.String() should return the email, got: %s", email.String())
-	}
-}
-
-func TestNewEmail_EmptyString_ReturnsError(t *testing.T) {
-	_, err := vo.NewEmail("")
-
-	if err == nil {
-		t.Error("NewEmail should return error for empty string")
-	}
-	if err != domainErrors.ErrEmailRequired {
-		t.Errorf("NewEmail should return ErrEmailRequired, got: %v", err)
-	}
-}
-
-func TestNewEmail_NoAtSign_ReturnsError(t *testing.T) {
-	_, err := vo.NewEmail("userexample.com")
-
-	if err == nil {
-		t.Error("NewEmail should return error for email without @")
-	}
-	if err != domainErrors.ErrInvalidEmailFormat {
-		t.Errorf("NewEmail should return ErrInvalidEmailFormat, got: %v", err)
-	}
-}
-
-func TestNewEmail_NoDomain_ReturnsError(t *testing.T) {
-	_, err := vo.NewEmail("user@")
-
-	if err == nil {
-		t.Error("NewEmail should return error for email without domain")
-	}
-	if err != domainErrors.ErrInvalidEmailFormat {
-		t.Errorf("NewEmail should return ErrInvalidEmailFormat, got: %v", err)
+			if err != tt.wantErr {
+				t.Errorf("NewEmail(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if err == nil && got.String() != tt.wantEmail {
+				t.Errorf("NewEmail(%q).String() = %v, want %v", tt.input, got.String(), tt.wantEmail)
+			}
+		})
 	}
 }
 
-func TestNewEmail_NoLocalPart_ReturnsError(t *testing.T) {
-	_, err := vo.NewEmail("@example.com")
-
-	if err == nil {
-		t.Error("NewEmail should return error for email without local part")
-	}
-	if err != domainErrors.ErrInvalidEmailFormat {
-		t.Errorf("NewEmail should return ErrInvalidEmailFormat, got: %v", err)
-	}
-}
-
-func TestNewEmail_MaxLength254_ReturnsEmail(t *testing.T) {
-	// Create email with exactly 254 characters
-	// local@domain.com format: local (max 64) + @ + domain
-	local := strings.Repeat("a", 64)
-	domain := strings.Repeat("b", 254-64-1-4) + ".com" // 254 - 64 - 1(@) - 4(.com)
-	email254 := local + "@" + domain
-
-	if len(email254) != 254 {
-		t.Fatalf("Test email should be 254 chars, got %d", len(email254))
+func TestEmail_Equals(t *testing.T) {
+	tests := []struct {
+		name   string
+		email1 string
+		email2 string
+		want   bool
+	}{
+		{"same value", "user@example.com", "user@example.com", true},
+		{"different value", "user1@example.com", "user2@example.com", false},
 	}
 
-	_, err := vo.NewEmail(email254)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e1, _ := vo.NewEmail(tt.email1)
+			e2, _ := vo.NewEmail(tt.email2)
 
-	if err != nil {
-		t.Errorf("NewEmail should accept 254 character email, got: %v", err)
-	}
-}
-
-func TestNewEmail_Exceeds254_ReturnsError(t *testing.T) {
-	// Create email with 255 characters
-	local := strings.Repeat("a", 64)
-	domain := strings.Repeat("b", 255-64-1-4) + ".com"
-	email255 := local + "@" + domain
-
-	if len(email255) != 255 {
-		t.Fatalf("Test email should be 255 chars, got %d", len(email255))
-	}
-
-	_, err := vo.NewEmail(email255)
-
-	if err == nil {
-		t.Error("NewEmail should return error for email exceeding 254 characters")
-	}
-	if err != domainErrors.ErrEmailTooLong {
-		t.Errorf("NewEmail should return ErrEmailTooLong, got: %v", err)
-	}
-}
-
-func TestEmail_Equals_SameValue_ReturnsTrue(t *testing.T) {
-	email1, _ := vo.NewEmail("user@example.com")
-	email2, _ := vo.NewEmail("user@example.com")
-
-	if !email1.Equals(email2) {
-		t.Error("Equals should return true for same email value")
-	}
-}
-
-func TestEmail_Equals_DifferentValue_ReturnsFalse(t *testing.T) {
-	email1, _ := vo.NewEmail("user1@example.com")
-	email2, _ := vo.NewEmail("user2@example.com")
-
-	if email1.Equals(email2) {
-		t.Error("Equals should return false for different email values")
+			if got := e1.Equals(e2); got != tt.want {
+				t.Errorf("Email.Equals() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/backend/domain/vo/nickname_test.go
+++ b/backend/domain/vo/nickname_test.go
@@ -8,62 +8,36 @@ import (
 	"caltrack/domain/vo"
 )
 
-func TestNewNickname_ValidNickname_ReturnsNickname(t *testing.T) {
-	nickname, err := vo.NewNickname("John")
-
-	if err != nil {
-		t.Errorf("NewNickname should not return error for valid nickname, got: %v", err)
+func TestNewNickname(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantNickname string
+		wantErr      error
+	}{
+		// 正常系
+		{"valid nickname", "John", "John", nil},
+		{"valid with spaces", "John Doe", "John Doe", nil},
+		// 異常系
+		{"empty string", "", "", domainErrors.ErrNicknameRequired},
+		{"too long 51 chars", strings.Repeat("a", 51), "", domainErrors.ErrNicknameTooLong},
+		// 境界値
+		{"min length 1 char", "A", "A", nil},
+		{"max length 50 chars", strings.Repeat("a", 50), strings.Repeat("a", 50), nil},
+		{"exceeds 50 chars", strings.Repeat("a", 51), "", domainErrors.ErrNicknameTooLong},
 	}
-	if nickname.String() != "John" {
-		t.Errorf("Nickname.String() should return the nickname, got: %s", nickname.String())
-	}
-}
 
-func TestNewNickname_EmptyString_ReturnsError(t *testing.T) {
-	_, err := vo.NewNickname("")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vo.NewNickname(tt.input)
 
-	if err == nil {
-		t.Error("NewNickname should return error for empty string")
-	}
-	if err != domainErrors.ErrNicknameRequired {
-		t.Errorf("NewNickname should return ErrNicknameRequired, got: %v", err)
-	}
-}
-
-func TestNewNickname_TooLong51_ReturnsError(t *testing.T) {
-	longNickname := strings.Repeat("a", 51)
-	_, err := vo.NewNickname(longNickname)
-
-	if err == nil {
-		t.Error("NewNickname should return error for 51 char nickname")
-	}
-	if err != domainErrors.ErrNicknameTooLong {
-		t.Errorf("NewNickname should return ErrNicknameTooLong, got: %v", err)
-	}
-}
-
-func TestNewNickname_MinLength1_ReturnsNickname(t *testing.T) {
-	_, err := vo.NewNickname("A")
-
-	if err != nil {
-		t.Errorf("NewNickname should accept 1 char nickname, got: %v", err)
-	}
-}
-
-func TestNewNickname_MaxLength50_ReturnsNickname(t *testing.T) {
-	nickname50 := strings.Repeat("a", 50)
-	_, err := vo.NewNickname(nickname50)
-
-	if err != nil {
-		t.Errorf("NewNickname should accept 50 char nickname, got: %v", err)
-	}
-}
-
-func TestNewNickname_Exceeds50_ReturnsError(t *testing.T) {
-	nickname51 := strings.Repeat("a", 51)
-	_, err := vo.NewNickname(nickname51)
-
-	if err == nil {
-		t.Error("NewNickname should reject 51 char nickname")
+			if err != tt.wantErr {
+				t.Errorf("NewNickname(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if err == nil && got.String() != tt.wantNickname {
+				t.Errorf("NewNickname(%q).String() = %v, want %v", tt.input, got.String(), tt.wantNickname)
+			}
+		})
 	}
 }

--- a/backend/domain/vo/weight.go
+++ b/backend/domain/vo/weight.go
@@ -1,0 +1,25 @@
+package vo
+
+import (
+	domainErrors "caltrack/domain/errors"
+)
+
+const maxWeight = 500.0
+
+type Weight struct {
+	value float64
+}
+
+func NewWeight(kg float64) (Weight, error) {
+	if kg <= 0 {
+		return Weight{}, domainErrors.ErrWeightMustBePositive
+	}
+	if kg > maxWeight {
+		return Weight{}, domainErrors.ErrWeightTooHeavy
+	}
+	return Weight{value: kg}, nil
+}
+
+func (w Weight) Kg() float64 {
+	return w.value
+}

--- a/backend/domain/vo/weight_test.go
+++ b/backend/domain/vo/weight_test.go
@@ -1,0 +1,43 @@
+package vo_test
+
+import (
+	"testing"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+)
+
+func TestNewWeight(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   float64
+		wantKg  float64
+		wantErr error
+	}{
+		// 正常系
+		{"valid weight 70.5kg", 70.5, 70.5, nil},
+		{"valid weight 1kg", 1.0, 1.0, nil},
+		// 異常系
+		{"zero", 0, 0, domainErrors.ErrWeightMustBePositive},
+		{"negative", -10, 0, domainErrors.ErrWeightMustBePositive},
+		{"too heavy 501kg", 501, 0, domainErrors.ErrWeightTooHeavy},
+		// 境界値
+		{"min positive 0.1kg", 0.1, 0.1, nil},
+		{"max weight 500kg", 500, 500, nil},
+		{"exceeds max 500.1kg", 500.1, 0, domainErrors.ErrWeightTooHeavy},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vo.NewWeight(tt.input)
+
+			if err != tt.wantErr {
+				t.Errorf("NewWeight(%v) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if err == nil && got.Kg() != tt.wantKg {
+				t.Errorf("NewWeight(%v).Kg() = %v, want %v", tt.input, got.Kg(), tt.wantKg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #13

## 概要
- Weight VO の実装（正の数、最大500kg）
- 全VOテストをテーブル駆動に修正

## テスト結果
- Build: ✅ Pass
- Test: ✅ Pass

## 設計Issue
詳細設計は #13 を参照