### PR TITLE
feat(domain): User Entity の実装

### DIFF
--- a/.claude/rules/domain-layer.md
+++ b/.claude/rules/domain-layer.md
@@ -30,8 +30,31 @@ paths:
 - Getterで値を公開
 
 ### ファクトリ関数
-- `New{Entity}()`: 新規作成（バリデーションあり）
-- `Reconstruct{Entity}()`: DB復元用（バリデーションなし）
+- `New{Entity}()`: 新規作成（プリミティブ型を受け取り、内部でVO変換、エラーをまとめて返す）
+- `Reconstruct{Entity}()`: DB復元用（VOを直接受け取る、バリデーションなし）
+
+### VO変換パターン
+- Entity内でプリミティブ→VO変換は専用のparse関数に分離
+- 条件分岐のネストを避け、フラットに保つ
+- エラーは`appendIfErr`等で集約し、最後にまとめて返す
+
+```go
+// 良い例
+func NewUser(emailStr string, ...) (*User, []error) {
+    var errs []error
+    email, err := parseEmail(emailStr)
+    errs = appendIfErr(errs, err)
+    // ...
+    if len(errs) > 0 {
+        return nil, errs
+    }
+    return &User{...}, nil
+}
+
+func parseEmail(s string) (vo.Email, error) {
+    return vo.NewEmail(s)
+}
+```
 
 ### 振る舞い
 - ドメインロジックはEntityのメソッドとして実装

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -22,18 +22,29 @@ Test{対象}_{条件}_{期待結果}
 
 ## テーブル駆動テスト
 
-境界値テストはテーブル駆動で:
+**使うべき場面:**
+- 同じロジックを異なる入力でテストする場合
+- 境界値テスト
+- 入力→出力が単純なマッピングの場合
+
+**使わないべき場面:**
+- テストごとに検証ロジックが異なる場合
+- 条件分岐がテスト内で多くなる場合
+- 正常系の詳細な検証（個別テストの方が読みやすい）
 
 ```go
+// 良い例: シンプルなバリデーションエラーテスト
 tests := []struct {
     name    string
     input   string
-    want    Type
     wantErr error
 }{
-    {"valid case", "input", expected, nil},
-    {"invalid case", "bad", nil, ErrInvalid},
+    {"invalid email", "invalid", ErrInvalidEmailFormat},
+    {"empty email", "", ErrEmailRequired},
 }
+
+// 悪い例: 条件分岐が多いテーブル駆動
+// → 個別のテスト関数に分ける
 ```
 
 ## モック戦略

--- a/backend/domain/entity/user.go
+++ b/backend/domain/entity/user.go
@@ -1,0 +1,183 @@
+package entity
+
+import (
+	"time"
+
+	"caltrack/domain/vo"
+)
+
+type User struct {
+	id             vo.UserID
+	email          vo.Email
+	hashedPassword vo.HashedPassword
+	nickname       vo.Nickname
+	weight         vo.Weight
+	height         vo.Height
+	birthDate      vo.BirthDate
+	gender         vo.Gender
+	activityLevel  vo.ActivityLevel
+	createdAt      time.Time
+	updatedAt      time.Time
+}
+
+func NewUser(
+	emailStr string,
+	hashedPasswordStr string,
+	nicknameStr string,
+	weightVal float64,
+	heightVal float64,
+	birthDateVal time.Time,
+	genderStr string,
+	activityLevelStr string,
+) (*User, []error) {
+	var errs []error
+
+	email, err := parseEmail(emailStr)
+	errs = appendIfErr(errs, err)
+
+	hashedPassword := vo.NewHashedPassword(hashedPasswordStr)
+
+	nickname, err := parseNickname(nicknameStr)
+	errs = appendIfErr(errs, err)
+
+	weight, err := parseWeight(weightVal)
+	errs = appendIfErr(errs, err)
+
+	height, err := parseHeight(heightVal)
+	errs = appendIfErr(errs, err)
+
+	birthDate, err := parseBirthDate(birthDateVal)
+	errs = appendIfErr(errs, err)
+
+	gender, err := parseGender(genderStr)
+	errs = appendIfErr(errs, err)
+
+	activityLevel, err := parseActivityLevel(activityLevelStr)
+	errs = appendIfErr(errs, err)
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	now := time.Now()
+	return &User{
+		id:             vo.NewUserID(),
+		email:          email,
+		hashedPassword: hashedPassword,
+		nickname:       nickname,
+		weight:         weight,
+		height:         height,
+		birthDate:      birthDate,
+		gender:         gender,
+		activityLevel:  activityLevel,
+		createdAt:      now,
+		updatedAt:      now,
+	}, nil
+}
+
+func appendIfErr(errs []error, err error) []error {
+	if err != nil {
+		return append(errs, err)
+	}
+	return errs
+}
+
+func parseEmail(s string) (vo.Email, error) {
+	return vo.NewEmail(s)
+}
+
+func parseNickname(s string) (vo.Nickname, error) {
+	return vo.NewNickname(s)
+}
+
+func parseWeight(v float64) (vo.Weight, error) {
+	return vo.NewWeight(v)
+}
+
+func parseHeight(v float64) (vo.Height, error) {
+	return vo.NewHeight(v)
+}
+
+func parseBirthDate(v time.Time) (vo.BirthDate, error) {
+	return vo.NewBirthDate(v)
+}
+
+func parseGender(s string) (vo.Gender, error) {
+	return vo.NewGender(s)
+}
+
+func parseActivityLevel(s string) (vo.ActivityLevel, error) {
+	return vo.NewActivityLevel(s)
+}
+
+func ReconstructUser(
+	id vo.UserID,
+	email vo.Email,
+	hashedPassword vo.HashedPassword,
+	nickname vo.Nickname,
+	weight vo.Weight,
+	height vo.Height,
+	birthDate vo.BirthDate,
+	gender vo.Gender,
+	activityLevel vo.ActivityLevel,
+	createdAt time.Time,
+	updatedAt time.Time,
+) *User {
+	return &User{
+		id:             id,
+		email:          email,
+		hashedPassword: hashedPassword,
+		nickname:       nickname,
+		weight:         weight,
+		height:         height,
+		birthDate:      birthDate,
+		gender:         gender,
+		activityLevel:  activityLevel,
+		createdAt:      createdAt,
+		updatedAt:      updatedAt,
+	}
+}
+
+func (u *User) ID() vo.UserID {
+	return u.id
+}
+
+func (u *User) Email() vo.Email {
+	return u.email
+}
+
+func (u *User) HashedPassword() vo.HashedPassword {
+	return u.hashedPassword
+}
+
+func (u *User) Nickname() vo.Nickname {
+	return u.nickname
+}
+
+func (u *User) Weight() vo.Weight {
+	return u.weight
+}
+
+func (u *User) Height() vo.Height {
+	return u.height
+}
+
+func (u *User) BirthDate() vo.BirthDate {
+	return u.birthDate
+}
+
+func (u *User) Gender() vo.Gender {
+	return u.gender
+}
+
+func (u *User) ActivityLevel() vo.ActivityLevel {
+	return u.activityLevel
+}
+
+func (u *User) CreatedAt() time.Time {
+	return u.createdAt
+}
+
+func (u *User) UpdatedAt() time.Time {
+	return u.updatedAt
+}

--- a/backend/domain/entity/user_test.go
+++ b/backend/domain/entity/user_test.go
@@ -1,0 +1,123 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/entity"
+	"caltrack/domain/vo"
+)
+
+func TestNewUser_Success(t *testing.T) {
+	birthDate := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	user, errs := entity.NewUser(
+		"test@example.com",
+		"$2a$10$hashedpassword",
+		"testuser",
+		70.5,
+		175.0,
+		birthDate,
+		"male",
+		"moderate",
+	)
+
+	if errs != nil {
+		t.Fatalf("NewUser() unexpected errors: %v", errs)
+	}
+	if user.ID().String() == "" {
+		t.Error("ID should not be empty")
+	}
+	if user.Email().String() != "test@example.com" {
+		t.Errorf("Email = %v, want test@example.com", user.Email().String())
+	}
+	if user.Nickname().String() != "testuser" {
+		t.Errorf("Nickname = %v, want testuser", user.Nickname().String())
+	}
+	if user.Weight().Kg() != 70.5 {
+		t.Errorf("Weight = %v, want 70.5", user.Weight().Kg())
+	}
+	if user.Height().Cm() != 175.0 {
+		t.Errorf("Height = %v, want 175.0", user.Height().Cm())
+	}
+	if user.Gender().String() != "male" {
+		t.Errorf("Gender = %v, want male", user.Gender().String())
+	}
+	if user.ActivityLevel().String() != "moderate" {
+		t.Errorf("ActivityLevel = %v, want moderate", user.ActivityLevel().String())
+	}
+}
+
+func TestNewUser_ValidationErrors(t *testing.T) {
+	birthDate := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		email   string
+		wantErr error
+	}{
+		{"invalid email", "invalid", domainErrors.ErrInvalidEmailFormat},
+		{"empty email", "", domainErrors.ErrEmailRequired},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := entity.NewUser(tt.email, "$2a$10$hash", "nick", 70, 170, birthDate, "male", "moderate")
+			if len(errs) != 1 || errs[0] != tt.wantErr {
+				t.Errorf("got errs = %v, want [%v]", errs, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewUser_MultipleErrors(t *testing.T) {
+	birthDate := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	_, errs := entity.NewUser("", "$2a$10$hash", "", -1, 400, birthDate, "invalid", "unknown")
+
+	if len(errs) != 6 {
+		t.Fatalf("got %d errors, want 6: %v", len(errs), errs)
+	}
+}
+
+func TestNewUser_GeneratesUniqueIDs(t *testing.T) {
+	birthDate := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	user1, _ := entity.NewUser("test@example.com", "$2a$10$hash", "nick", 70, 170, birthDate, "male", "moderate")
+	user2, _ := entity.NewUser("test@example.com", "$2a$10$hash", "nick", 70, 170, birthDate, "male", "moderate")
+
+	if user1.ID().Equals(user2.ID()) {
+		t.Error("should generate unique IDs")
+	}
+}
+
+func TestReconstructUser(t *testing.T) {
+	userID := vo.NewUserID()
+	email, _ := vo.NewEmail("test@example.com")
+	hashedPassword := vo.NewHashedPassword("$2a$10$hashedpassword")
+	nickname, _ := vo.NewNickname("testuser")
+	weight, _ := vo.NewWeight(70.5)
+	height, _ := vo.NewHeight(175.0)
+	birthDate, _ := vo.NewBirthDate(time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC))
+	gender, _ := vo.NewGender("male")
+	activityLevel, _ := vo.NewActivityLevel("moderate")
+	createdAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	user := entity.ReconstructUser(
+		userID, email, hashedPassword, nickname,
+		weight, height, birthDate, gender, activityLevel,
+		createdAt, updatedAt,
+	)
+
+	if !user.ID().Equals(userID) {
+		t.Errorf("ID mismatch")
+	}
+	if !user.CreatedAt().Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", user.CreatedAt(), createdAt)
+	}
+	if !user.UpdatedAt().Equal(updatedAt) {
+		t.Errorf("UpdatedAt = %v, want %v", user.UpdatedAt(), updatedAt)
+	}
+}


### PR DESCRIPTION
## Summary
- NewUser(): プリミティブ型を受け取り内部でVO変換、エラーをまとめて返す
- ReconstructUser(): DB復元用（VO直接受け取り）
- 各VOごとのparse関数で条件分岐をフラットに
- domain-layer.md/testing.md にルール追記

## Test plan
- [x] `go test ./domain/entity/...` 全テスト合格

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)