### PR TITLE
feat(usecase): RegisterUser Usecase の実装

### DIFF
--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -19,4 +19,7 @@ var (
 	ErrBirthDateTooOld      = errors.New("birth date must be within 150 years")
 	ErrInvalidGender        = errors.New("gender must be male, female, or other")
 	ErrInvalidActivityLevel = errors.New("activity level must be sedentary, light, moderate, active, or veryActive")
+
+	// Usecase errors
+	ErrEmailAlreadyExists = errors.New("email already exists")
 )

--- a/backend/domain/repository/transaction.go
+++ b/backend/domain/repository/transaction.go
@@ -1,0 +1,7 @@
+package repository
+
+import "context"
+
+type TransactionManager interface {
+	Execute(ctx context.Context, fn func(ctx context.Context) error) error
+}

--- a/backend/domain/repository/user_repository.go
+++ b/backend/domain/repository/user_repository.go
@@ -1,0 +1,14 @@
+package repository
+
+import (
+	"context"
+
+	"caltrack/domain/entity"
+	"caltrack/domain/vo"
+)
+
+type UserRepository interface {
+	Save(ctx context.Context, user *entity.User) error
+	FindByEmail(ctx context.Context, email vo.Email) (*entity.User, error)
+	ExistsByEmail(ctx context.Context, email vo.Email) (bool, error)
+}

--- a/backend/usecase/user/register_user.go
+++ b/backend/usecase/user/register_user.go
@@ -1,0 +1,100 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/repository"
+	"caltrack/domain/vo"
+)
+
+type RegisterUserInput struct {
+	Email         string
+	Password      string
+	Nickname      string
+	Weight        float64
+	Height        float64
+	BirthDate     time.Time
+	Gender        string
+	ActivityLevel string
+}
+
+type RegisterUserOutput struct {
+	UserID string
+}
+
+type RegisterUserUsecase struct {
+	userRepo  repository.UserRepository
+	txManager repository.TransactionManager
+}
+
+func NewRegisterUserUsecase(
+	userRepo repository.UserRepository,
+	txManager repository.TransactionManager,
+) *RegisterUserUsecase {
+	return &RegisterUserUsecase{
+		userRepo:  userRepo,
+		txManager: txManager,
+	}
+}
+
+func (u *RegisterUserUsecase) Execute(ctx context.Context, input RegisterUserInput) (*RegisterUserOutput, error) {
+	email, err := vo.NewEmail(input.Email)
+	if err != nil {
+		return nil, err
+	}
+
+	password, err := vo.NewPassword(input.Password)
+	if err != nil {
+		return nil, err
+	}
+
+	hashedPassword, err := password.Hash()
+	if err != nil {
+		return nil, err
+	}
+
+	var output *RegisterUserOutput
+
+	err = u.txManager.Execute(ctx, func(txCtx context.Context) error {
+		exists, err := u.userRepo.ExistsByEmail(txCtx, email)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return domainErrors.ErrEmailAlreadyExists
+		}
+
+		user, errs := entity.NewUser(
+			input.Email,
+			hashedPassword.String(),
+			input.Nickname,
+			input.Weight,
+			input.Height,
+			input.BirthDate,
+			input.Gender,
+			input.ActivityLevel,
+		)
+		if errs != nil {
+			return errors.Join(errs...)
+		}
+
+		if err := u.userRepo.Save(txCtx, user); err != nil {
+			return err
+		}
+
+		output = &RegisterUserOutput{
+			UserID: user.ID().String(),
+		}
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/backend/usecase/user/register_user_test.go
+++ b/backend/usecase/user/register_user_test.go
@@ -1,0 +1,204 @@
+package user_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+	"caltrack/usecase/user"
+)
+
+type mockUserRepository struct {
+	existsByEmail func(ctx context.Context, email vo.Email) (bool, error)
+	save          func(ctx context.Context, user *entity.User) error
+}
+
+func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
+	return m.existsByEmail(ctx, email)
+}
+
+func (m *mockUserRepository) Save(ctx context.Context, u *entity.User) error {
+	return m.save(ctx, u)
+}
+
+func (m *mockUserRepository) FindByEmail(ctx context.Context, email vo.Email) (*entity.User, error) {
+	return nil, nil
+}
+
+type mockTransactionManager struct{}
+
+func (m *mockTransactionManager) Execute(ctx context.Context, fn func(ctx context.Context) error) error {
+	return fn(ctx)
+}
+
+func validInput() user.RegisterUserInput {
+	return user.RegisterUserInput{
+		Email:         "test@example.com",
+		Password:      "password123",
+		Nickname:      "testuser",
+		Weight:        70.5,
+		Height:        175.0,
+		BirthDate:     time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+		Gender:        "male",
+		ActivityLevel: "moderate",
+	}
+}
+
+func TestRegisterUserUsecase_Success(t *testing.T) {
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return false, nil
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	output, err := uc.Execute(context.Background(), validInput())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output.UserID == "" {
+		t.Error("UserID should not be empty")
+	}
+}
+
+func TestRegisterUserUsecase_EmailAlreadyExists(t *testing.T) {
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return true, nil
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	_, err := uc.Execute(context.Background(), validInput())
+
+	if err != domainErrors.ErrEmailAlreadyExists {
+		t.Errorf("got %v, want ErrEmailAlreadyExists", err)
+	}
+}
+
+func TestRegisterUserUsecase_InvalidEmail(t *testing.T) {
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return false, nil
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	input := validInput()
+	input.Email = "invalid"
+
+	_, err := uc.Execute(context.Background(), input)
+
+	if !errors.Is(err, domainErrors.ErrInvalidEmailFormat) {
+		t.Errorf("got %v, want ErrInvalidEmailFormat", err)
+	}
+}
+
+func TestRegisterUserUsecase_InvalidPassword(t *testing.T) {
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return false, nil
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	input := validInput()
+	input.Password = "short"
+
+	_, err := uc.Execute(context.Background(), input)
+
+	if err != domainErrors.ErrPasswordTooShort {
+		t.Errorf("got %v, want ErrPasswordTooShort", err)
+	}
+}
+
+func TestRegisterUserUsecase_RepositoryError(t *testing.T) {
+	repoErr := errors.New("db error")
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return false, repoErr
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	_, err := uc.Execute(context.Background(), validInput())
+
+	if err != repoErr {
+		t.Errorf("got %v, want repoErr", err)
+	}
+}
+
+func TestRegisterUserUsecase_SaveError(t *testing.T) {
+	saveErr := errors.New("save error")
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return false, nil
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return saveErr
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	_, err := uc.Execute(context.Background(), validInput())
+
+	if !errors.Is(err, saveErr) {
+		t.Errorf("got %v, want saveErr", err)
+	}
+}
+
+func TestRegisterUserUsecase_MultipleValidationErrors(t *testing.T) {
+	repo := &mockUserRepository{
+		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+			return false, nil
+		},
+		save: func(ctx context.Context, u *entity.User) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+
+	uc := user.NewRegisterUserUsecase(repo, txManager)
+	input := validInput()
+	input.Nickname = ""
+	input.Weight = -1
+	input.Gender = "invalid"
+
+	_, err := uc.Execute(context.Background(), input)
+
+	if !errors.Is(err, domainErrors.ErrNicknameRequired) {
+		t.Errorf("should contain ErrNicknameRequired: %v", err)
+	}
+	if !errors.Is(err, domainErrors.ErrWeightMustBePositive) {
+		t.Errorf("should contain ErrWeightMustBePositive: %v", err)
+	}
+	if !errors.Is(err, domainErrors.ErrInvalidGender) {
+		t.Errorf("should contain ErrInvalidGender: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- TransactionManager Interface追加（Domain層）
- UserRepository Interface追加（Domain層）
- RegisterUserUsecase実装（トランザクション対応）
- errors.Joinで複数バリデーションエラー返却

## Test plan
- [x] `go test ./usecase/...` 全テスト合格（7ケース）

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)