### PR TITLE
feat(frontend-ui): ユーザー登録UI Layer実装

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,11 +14,13 @@
         "lucide-react": "^0.441.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-router-dom": "^7.13.0",
         "tailwind-merge": "^2.5.2"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",
@@ -1395,6 +1397,20 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -2003,6 +2019,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -3313,6 +3342,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3496,6 +3563,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,11 +18,13 @@
     "lucide-react": "^0.441.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.13.0",
     "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,63 +1,18 @@
-import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+/**
+ * App - アプリケーションのルートコンポーネント
+ *
+ * React Routerを使用してルーティングを管理
+ */
+import { RouterProvider } from "react-router-dom";
+import { router } from "./routes";
 
-interface HealthStatus {
-  status: string
-  message: string
-}
-
+/**
+ * App - メインアプリケーションコンポーネント
+ *
+ * RouterProviderでルーティング機能を提供
+ */
 function App() {
-  const [health, setHealth] = useState<HealthStatus | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const checkHealth = async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const response = await fetch('http://localhost:8080/health')
-      const data = await response.json()
-      setHealth(data)
-    } catch (err) {
-      setError('Failed to connect to backend')
-      setHealth(null)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    checkHealth()
-  }, [])
-
-  return (
-    <div className="min-h-screen bg-background flex items-center justify-center p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader>
-          <CardTitle>CalTrack</CardTitle>
-          <CardDescription>
-            Calorie tracking application
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="text-sm">
-            <p className="font-medium">Backend Status:</p>
-            {loading && <p className="text-muted-foreground">Checking...</p>}
-            {error && <p className="text-destructive">{error}</p>}
-            {health && (
-              <p className="text-green-600">
-                {health.status}: {health.message}
-              </p>
-            )}
-          </div>
-          <Button onClick={checkHealth} disabled={loading}>
-            {loading ? 'Checking...' : 'Check Backend Health'}
-          </Button>
-        </CardContent>
-      </Card>
-    </div>
-  )
+  return <RouterProvider router={router} />;
 }
 
-export default App
+export default App;

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,29 @@
+/**
+ * Inputコンポーネント
+ * shadcn/uiスタイルのテキスト入力フィールド
+ */
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,29 @@
+/**
+ * Labelコンポーネント
+ * shadcn/uiスタイルのフォームラベル
+ */
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+export interface LabelProps
+  extends React.LabelHTMLAttributes<HTMLLabelElement>,
+    VariantProps<typeof labelVariants> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(labelVariants(), className)}
+      {...props}
+    />
+  )
+)
+Label.displayName = "Label"
+
+export { Label }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,41 @@
+/**
+ * Selectコンポーネント
+ * shadcn/uiスタイルのドロップダウン選択
+ * シンプルなnative select実装（Radix UIなしで動作）
+ */
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface SelectProps
+  extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      >
+        {children}
+      </select>
+    )
+  }
+)
+Select.displayName = "Select"
+
+export interface SelectOptionProps
+  extends React.OptionHTMLAttributes<HTMLOptionElement> {}
+
+const SelectOption = React.forwardRef<HTMLOptionElement, SelectOptionProps>(
+  ({ className, ...props }, ref) => {
+    return <option ref={ref} className={className} {...props} />
+  }
+)
+SelectOption.displayName = "SelectOption"
+
+export { Select, SelectOption }

--- a/frontend/src/features/auth/components/RegisterForm.test.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * RegisterForm コンポーネントのテスト
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { RegisterForm } from "./RegisterForm";
+import * as hooks from "../hooks";
+import { ApiError } from "../api";
+
+// useRegisterUserフックをモック
+vi.mock("../hooks", async () => {
+  const actual = await vi.importActual<typeof hooks>("../hooks");
+  return {
+    ...actual,
+    useRegisterUser: vi.fn(),
+  };
+});
+
+const mockUseRegisterUser = vi.mocked(hooks.useRegisterUser);
+
+describe("RegisterForm", () => {
+  const mockRegister = vi.fn();
+  const mockReset = vi.fn();
+
+  const defaultHookReturn: hooks.UseRegisterUserReturn = {
+    register: mockRegister,
+    isLoading: false,
+    error: null,
+    isSuccess: false,
+    reset: mockReset,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseRegisterUser.mockReturnValue(defaultHookReturn);
+  });
+
+  describe("レンダリング", () => {
+    it("すべてのフォームフィールドが表示される", () => {
+      render(<RegisterForm />);
+
+      expect(screen.getByLabelText("ニックネーム")).toBeInTheDocument();
+      expect(screen.getByLabelText("メールアドレス")).toBeInTheDocument();
+      expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+      expect(screen.getByLabelText("体重 (kg)")).toBeInTheDocument();
+      expect(screen.getByLabelText("身長 (cm)")).toBeInTheDocument();
+      expect(screen.getByLabelText("生年月日")).toBeInTheDocument();
+      expect(screen.getByLabelText("性別")).toBeInTheDocument();
+      expect(screen.getByLabelText("活動レベル")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "登録する" })).toBeInTheDocument();
+    });
+
+    it("タイトルと説明が表示される", () => {
+      render(<RegisterForm />);
+
+      expect(screen.getByText("新規登録")).toBeInTheDocument();
+      expect(
+        screen.getByText("アカウントを作成して、カロリー管理を始めましょう")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("空のフォームを送信するとバリデーションエラーが表示される", async () => {
+      render(<RegisterForm />);
+
+      fireEvent.click(screen.getByRole("button", { name: "登録する" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("ニックネームを入力してください")).toBeInTheDocument();
+        expect(screen.getByText("メールアドレスを入力してください")).toBeInTheDocument();
+        expect(screen.getByText("パスワードを入力してください")).toBeInTheDocument();
+        expect(screen.getByText("体重を入力してください")).toBeInTheDocument();
+        expect(screen.getByText("身長を入力してください")).toBeInTheDocument();
+        expect(screen.getByText("生年月日を入力してください")).toBeInTheDocument();
+        expect(screen.getByText("性別を選択してください")).toBeInTheDocument();
+        expect(screen.getByText("活動レベルを選択してください")).toBeInTheDocument();
+      });
+
+      // register関数は呼ばれない
+      expect(mockRegister).not.toHaveBeenCalled();
+    });
+
+    it("不正なメール形式でエラーが表示される", async () => {
+      render(<RegisterForm />);
+
+      // fireEvent.changeで直接値を設定
+      fireEvent.change(screen.getByLabelText("メールアドレス"), {
+        target: { value: "invalid-email" },
+      });
+      // フォームを直接サブミット（HTML5バリデーションをバイパス）
+      const form = screen.getByRole("button", { name: "登録する" }).closest("form");
+      fireEvent.submit(form!);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("正しいメールアドレス形式で入力してください")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("パスワードが8文字未満でエラーが表示される", async () => {
+      const user = userEvent.setup();
+      render(<RegisterForm />);
+
+      await user.type(screen.getByLabelText("パスワード"), "short");
+      fireEvent.click(screen.getByRole("button", { name: "登録する" }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("パスワードは8文字以上で入力してください")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("体重が0以下でエラーが表示される", async () => {
+      render(<RegisterForm />);
+
+      // fireEvent.changeで直接値を設定
+      fireEvent.change(screen.getByLabelText("体重 (kg)"), {
+        target: { value: "-10" },
+      });
+      // フォームを直接サブミット（HTML5バリデーションをバイパス）
+      const form = screen.getByRole("button", { name: "登録する" }).closest("form");
+      fireEvent.submit(form!);
+
+      await waitFor(() => {
+        expect(screen.getByText("正しい体重を入力してください")).toBeInTheDocument();
+      });
+    });
+
+    it("身長が0以下でエラーが表示される", async () => {
+      const user = userEvent.setup();
+      render(<RegisterForm />);
+
+      await user.type(screen.getByLabelText("身長 (cm)"), "0");
+      fireEvent.click(screen.getByRole("button", { name: "登録する" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("正しい身長を入力してください")).toBeInTheDocument();
+      });
+    });
+
+    it("未来の生年月日でエラーが表示される", async () => {
+      const user = userEvent.setup();
+      render(<RegisterForm />);
+
+      // 未来の日付を設定
+      const futureDate = new Date();
+      futureDate.setFullYear(futureDate.getFullYear() + 1);
+      const futureDateStr = futureDate.toISOString().split("T")[0];
+
+      await user.type(screen.getByLabelText("生年月日"), futureDateStr);
+      fireEvent.click(screen.getByRole("button", { name: "登録する" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("過去の日付を入力してください")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("フォーム送信", () => {
+    it("有効なデータでフォームを送信するとregister関数が呼ばれる", async () => {
+      const user = userEvent.setup();
+      render(<RegisterForm />);
+
+      // フォームに入力
+      await user.type(screen.getByLabelText("ニックネーム"), "TestUser");
+      await user.type(screen.getByLabelText("メールアドレス"), "test@example.com");
+      await user.type(screen.getByLabelText("パスワード"), "password123");
+      await user.type(screen.getByLabelText("体重 (kg)"), "70");
+      await user.type(screen.getByLabelText("身長 (cm)"), "175");
+      await user.type(screen.getByLabelText("生年月日"), "1990-01-01");
+      await user.selectOptions(screen.getByLabelText("性別"), "male");
+      await user.selectOptions(screen.getByLabelText("活動レベル"), "moderate");
+
+      // 送信
+      fireEvent.click(screen.getByRole("button", { name: "登録する" }));
+
+      await waitFor(() => {
+        expect(mockRegister).toHaveBeenCalledWith({
+          email: "test@example.com",
+          password: "password123",
+          nickname: "TestUser",
+          weight: 70,
+          height: 175,
+          birthDate: "1990-01-01",
+          gender: "male",
+          activityLevel: "moderate",
+        });
+      });
+    });
+  });
+
+  describe("ローディング状態", () => {
+    it("isLoadingがtrueの時、ボタンが無効化される", () => {
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: true,
+      });
+
+      render(<RegisterForm />);
+
+      const submitButton = screen.getByRole("button", { name: "登録中..." });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it("isLoadingがtrueの時、フォームフィールドが無効化される", () => {
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        isLoading: true,
+      });
+
+      render(<RegisterForm />);
+
+      expect(screen.getByLabelText("ニックネーム")).toBeDisabled();
+      expect(screen.getByLabelText("メールアドレス")).toBeDisabled();
+      expect(screen.getByLabelText("パスワード")).toBeDisabled();
+      expect(screen.getByLabelText("体重 (kg)")).toBeDisabled();
+      expect(screen.getByLabelText("身長 (cm)")).toBeDisabled();
+      expect(screen.getByLabelText("生年月日")).toBeDisabled();
+      expect(screen.getByLabelText("性別")).toBeDisabled();
+      expect(screen.getByLabelText("活動レベル")).toBeDisabled();
+    });
+  });
+
+  describe("エラー表示", () => {
+    it("EMAIL_ALREADY_EXISTSエラーが表示される", () => {
+      const error = new ApiError(
+        "EMAIL_ALREADY_EXISTS",
+        "Email already exists",
+        409
+      );
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        error,
+      });
+
+      render(<RegisterForm />);
+
+      expect(
+        screen.getByText("このメールアドレスは既に登録されています")
+      ).toBeInTheDocument();
+    });
+
+    it("VALIDATION_ERRORとdetailsが表示される", () => {
+      const error = new ApiError("VALIDATION_ERROR", "Validation failed", 400, [
+        "email: 不正な形式です",
+        "password: 短すぎます",
+      ]);
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        error,
+      });
+
+      render(<RegisterForm />);
+
+      expect(screen.getByText("入力内容に誤りがあります")).toBeInTheDocument();
+      expect(screen.getByText("email: 不正な形式です")).toBeInTheDocument();
+      expect(screen.getByText("password: 短すぎます")).toBeInTheDocument();
+    });
+
+    it("INTERNAL_ERRORが表示される", () => {
+      const error = new ApiError("INTERNAL_ERROR", "Internal error", 500);
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        error,
+      });
+
+      render(<RegisterForm />);
+
+      expect(
+        screen.getByText("予期しないエラーが発生しました")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("成功状態", () => {
+    it("isSuccessがtrueの時、成功メッセージが表示される", () => {
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        isSuccess: true,
+      });
+
+      render(<RegisterForm />);
+
+      expect(screen.getByText("登録が完了しました")).toBeInTheDocument();
+    });
+
+    it("isSuccessがtrueの時、onSuccessコールバックが呼ばれる", () => {
+      const onSuccess = vi.fn();
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        isSuccess: true,
+      });
+
+      render(<RegisterForm onSuccess={onSuccess} />);
+
+      expect(onSuccess).toHaveBeenCalled();
+    });
+  });
+
+  describe("エラーリセット", () => {
+    it("フィールド入力時にエラーがリセットされる", async () => {
+      const error = new ApiError(
+        "EMAIL_ALREADY_EXISTS",
+        "Email already exists",
+        409
+      );
+      mockUseRegisterUser.mockReturnValue({
+        ...defaultHookReturn,
+        error,
+      });
+
+      const user = userEvent.setup();
+      render(<RegisterForm />);
+
+      // エラーが表示されていることを確認
+      expect(
+        screen.getByText("このメールアドレスは既に登録されています")
+      ).toBeInTheDocument();
+
+      // フィールドに入力
+      await user.type(screen.getByLabelText("ニックネーム"), "a");
+
+      // reset関数が呼ばれることを確認
+      expect(mockReset).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -1,0 +1,445 @@
+/**
+ * RegisterForm - ユーザー登録フォームコンポーネント
+ * 新規ユーザー登録のためのフォームUI
+ */
+import * as React from "react";
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectOption } from "@/components/ui/select";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { useRegisterUser } from "../hooks";
+import type { Gender, ActivityLevel } from "../types";
+
+/** RegisterFormコンポーネントのProps */
+export interface RegisterFormProps {
+  /** 登録成功時のコールバック */
+  onSuccess?: () => void;
+}
+
+/** フォームの内部状態 */
+interface FormState {
+  email: string;
+  password: string;
+  nickname: string;
+  weight: string;
+  height: string;
+  birthDate: string;
+  gender: Gender | "";
+  activityLevel: ActivityLevel | "";
+}
+
+/** バリデーションエラー */
+interface FormErrors {
+  email?: string;
+  password?: string;
+  nickname?: string;
+  weight?: string;
+  height?: string;
+  birthDate?: string;
+  gender?: string;
+  activityLevel?: string;
+}
+
+/** フォームの初期状態 */
+const initialFormState: FormState = {
+  email: "",
+  password: "",
+  nickname: "",
+  weight: "",
+  height: "",
+  birthDate: "",
+  gender: "",
+  activityLevel: "",
+};
+
+/** 性別の選択肢 */
+const GENDER_OPTIONS = [
+  { value: "male", label: "男性" },
+  { value: "female", label: "女性" },
+  { value: "other", label: "その他" },
+] as const;
+
+/** 活動レベルの選択肢 */
+const ACTIVITY_LEVEL_OPTIONS = [
+  { value: "sedentary", label: "座りがち（運動なし）" },
+  { value: "light", label: "軽い（週1-3回運動）" },
+  { value: "moderate", label: "適度（週3-5回運動）" },
+  { value: "active", label: "活動的（週6-7回運動）" },
+  { value: "veryActive", label: "非常に活動的（毎日激しい運動）" },
+] as const;
+
+/**
+ * フォームバリデーション関数
+ * @param form - フォームの状態
+ * @returns バリデーションエラー
+ */
+function validateForm(form: FormState): FormErrors {
+  const errors: FormErrors = {};
+
+  // nickname: 必須
+  if (!form.nickname.trim()) {
+    errors.nickname = "ニックネームを入力してください";
+  }
+
+  // email: 必須、形式チェック
+  if (!form.email.trim()) {
+    errors.email = "メールアドレスを入力してください";
+  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+    errors.email = "正しいメールアドレス形式で入力してください";
+  }
+
+  // password: 必須、8文字以上
+  if (!form.password) {
+    errors.password = "パスワードを入力してください";
+  } else if (form.password.length < 8) {
+    errors.password = "パスワードは8文字以上で入力してください";
+  }
+
+  // weight: 必須、正の数
+  const weight = parseFloat(form.weight);
+  if (!form.weight) {
+    errors.weight = "体重を入力してください";
+  } else if (isNaN(weight) || weight <= 0) {
+    errors.weight = "正しい体重を入力してください";
+  }
+
+  // height: 必須、正の数
+  const height = parseFloat(form.height);
+  if (!form.height) {
+    errors.height = "身長を入力してください";
+  } else if (isNaN(height) || height <= 0) {
+    errors.height = "正しい身長を入力してください";
+  }
+
+  // birthDate: 必須、過去の日付
+  if (!form.birthDate) {
+    errors.birthDate = "生年月日を入力してください";
+  } else if (new Date(form.birthDate) >= new Date()) {
+    errors.birthDate = "過去の日付を入力してください";
+  }
+
+  // gender: 必須
+  if (!form.gender) {
+    errors.gender = "性別を選択してください";
+  }
+
+  // activityLevel: 必須
+  if (!form.activityLevel) {
+    errors.activityLevel = "活動レベルを選択してください";
+  }
+
+  return errors;
+}
+
+/**
+ * APIエラーコードからユーザー向けメッセージを取得
+ * @param code - エラーコード
+ * @returns ユーザー向けメッセージ
+ */
+function getErrorMessage(code: string): string {
+  switch (code) {
+    case "EMAIL_ALREADY_EXISTS":
+      return "このメールアドレスは既に登録されています";
+    case "VALIDATION_ERROR":
+      return "入力内容に誤りがあります";
+    default:
+      return "予期しないエラーが発生しました";
+  }
+}
+
+/**
+ * RegisterForm - ユーザー登録フォーム
+ */
+export function RegisterForm({ onSuccess }: RegisterFormProps) {
+  const [formState, setFormState] = useState<FormState>(initialFormState);
+  const [formErrors, setFormErrors] = useState<FormErrors>({});
+  const { register, isLoading, error, isSuccess, reset } = useRegisterUser();
+
+  // 成功時にコールバックを呼び出す
+  useEffect(() => {
+    if (isSuccess) {
+      onSuccess?.();
+    }
+  }, [isSuccess, onSuccess]);
+
+  /**
+   * フィールド値の変更ハンドラ
+   */
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
+    const { name, value } = e.target;
+    setFormState((prev) => ({ ...prev, [name]: value }));
+    // 該当フィールドのエラーをクリア
+    if (formErrors[name as keyof FormErrors]) {
+      setFormErrors((prev) => ({ ...prev, [name]: undefined }));
+    }
+    // APIエラーをリセット
+    if (error) {
+      reset();
+    }
+  };
+
+  /**
+   * フォーム送信ハンドラ
+   */
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // バリデーション
+    const errors = validateForm(formState);
+    if (Object.keys(errors).length > 0) {
+      setFormErrors(errors);
+      return;
+    }
+
+    // API呼び出し
+    await register({
+      email: formState.email,
+      password: formState.password,
+      nickname: formState.nickname,
+      weight: parseFloat(formState.weight),
+      height: parseFloat(formState.height),
+      birthDate: formState.birthDate,
+      gender: formState.gender as Gender,
+      activityLevel: formState.activityLevel as ActivityLevel,
+    });
+  };
+
+  return (
+    <Card className="w-full max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle>新規登録</CardTitle>
+        <CardDescription>
+          アカウントを作成して、カロリー管理を始めましょう
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* APIエラー表示 */}
+          {error && (
+            <div
+              className="p-3 text-sm text-red-500 bg-red-50 border border-red-200 rounded-md"
+              role="alert"
+            >
+              <p>{getErrorMessage(error.code)}</p>
+              {error.details && error.details.length > 0 && (
+                <ul className="mt-1 list-disc list-inside">
+                  {error.details.map((detail, index) => (
+                    <li key={index}>{detail}</li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          )}
+
+          {/* 成功メッセージ */}
+          {isSuccess && (
+            <div
+              className="p-3 text-sm text-green-500 bg-green-50 border border-green-200 rounded-md"
+              role="status"
+            >
+              登録が完了しました
+            </div>
+          )}
+
+          {/* ニックネーム */}
+          <div className="space-y-2">
+            <Label htmlFor="nickname">ニックネーム</Label>
+            <Input
+              id="nickname"
+              name="nickname"
+              type="text"
+              value={formState.nickname}
+              onChange={handleChange}
+              placeholder="ニックネームを入力"
+              disabled={isLoading}
+              aria-invalid={!!formErrors.nickname}
+              aria-describedby={formErrors.nickname ? "nickname-error" : undefined}
+            />
+            {formErrors.nickname && (
+              <p id="nickname-error" className="text-sm text-red-500">
+                {formErrors.nickname}
+              </p>
+            )}
+          </div>
+
+          {/* メールアドレス */}
+          <div className="space-y-2">
+            <Label htmlFor="email">メールアドレス</Label>
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              value={formState.email}
+              onChange={handleChange}
+              placeholder="example@example.com"
+              disabled={isLoading}
+              aria-invalid={!!formErrors.email}
+              aria-describedby={formErrors.email ? "email-error" : undefined}
+            />
+            {formErrors.email && (
+              <p id="email-error" className="text-sm text-red-500">
+                {formErrors.email}
+              </p>
+            )}
+          </div>
+
+          {/* パスワード */}
+          <div className="space-y-2">
+            <Label htmlFor="password">パスワード</Label>
+            <Input
+              id="password"
+              name="password"
+              type="password"
+              value={formState.password}
+              onChange={handleChange}
+              placeholder="8文字以上で入力"
+              disabled={isLoading}
+              aria-invalid={!!formErrors.password}
+              aria-describedby={formErrors.password ? "password-error" : undefined}
+            />
+            {formErrors.password && (
+              <p id="password-error" className="text-sm text-red-500">
+                {formErrors.password}
+              </p>
+            )}
+          </div>
+
+          {/* 体重 */}
+          <div className="space-y-2">
+            <Label htmlFor="weight">体重 (kg)</Label>
+            <Input
+              id="weight"
+              name="weight"
+              type="number"
+              step="0.1"
+              min="0"
+              value={formState.weight}
+              onChange={handleChange}
+              placeholder="60"
+              disabled={isLoading}
+              aria-invalid={!!formErrors.weight}
+              aria-describedby={formErrors.weight ? "weight-error" : undefined}
+            />
+            {formErrors.weight && (
+              <p id="weight-error" className="text-sm text-red-500">
+                {formErrors.weight}
+              </p>
+            )}
+          </div>
+
+          {/* 身長 */}
+          <div className="space-y-2">
+            <Label htmlFor="height">身長 (cm)</Label>
+            <Input
+              id="height"
+              name="height"
+              type="number"
+              step="0.1"
+              min="0"
+              value={formState.height}
+              onChange={handleChange}
+              placeholder="170"
+              disabled={isLoading}
+              aria-invalid={!!formErrors.height}
+              aria-describedby={formErrors.height ? "height-error" : undefined}
+            />
+            {formErrors.height && (
+              <p id="height-error" className="text-sm text-red-500">
+                {formErrors.height}
+              </p>
+            )}
+          </div>
+
+          {/* 生年月日 */}
+          <div className="space-y-2">
+            <Label htmlFor="birthDate">生年月日</Label>
+            <Input
+              id="birthDate"
+              name="birthDate"
+              type="date"
+              value={formState.birthDate}
+              onChange={handleChange}
+              disabled={isLoading}
+              aria-invalid={!!formErrors.birthDate}
+              aria-describedby={formErrors.birthDate ? "birthDate-error" : undefined}
+            />
+            {formErrors.birthDate && (
+              <p id="birthDate-error" className="text-sm text-red-500">
+                {formErrors.birthDate}
+              </p>
+            )}
+          </div>
+
+          {/* 性別 */}
+          <div className="space-y-2">
+            <Label htmlFor="gender">性別</Label>
+            <Select
+              id="gender"
+              name="gender"
+              value={formState.gender}
+              onChange={handleChange}
+              disabled={isLoading}
+              aria-invalid={!!formErrors.gender}
+              aria-describedby={formErrors.gender ? "gender-error" : undefined}
+            >
+              <SelectOption value="">選択してください</SelectOption>
+              {GENDER_OPTIONS.map((option) => (
+                <SelectOption key={option.value} value={option.value}>
+                  {option.label}
+                </SelectOption>
+              ))}
+            </Select>
+            {formErrors.gender && (
+              <p id="gender-error" className="text-sm text-red-500">
+                {formErrors.gender}
+              </p>
+            )}
+          </div>
+
+          {/* 活動レベル */}
+          <div className="space-y-2">
+            <Label htmlFor="activityLevel">活動レベル</Label>
+            <Select
+              id="activityLevel"
+              name="activityLevel"
+              value={formState.activityLevel}
+              onChange={handleChange}
+              disabled={isLoading}
+              aria-invalid={!!formErrors.activityLevel}
+              aria-describedby={
+                formErrors.activityLevel ? "activityLevel-error" : undefined
+              }
+            >
+              <SelectOption value="">選択してください</SelectOption>
+              {ACTIVITY_LEVEL_OPTIONS.map((option) => (
+                <SelectOption key={option.value} value={option.value}>
+                  {option.label}
+                </SelectOption>
+              ))}
+            </Select>
+            {formErrors.activityLevel && (
+              <p id="activityLevel-error" className="text-sm text-red-500">
+                {formErrors.activityLevel}
+              </p>
+            )}
+          </div>
+
+          {/* 送信ボタン */}
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? "登録中..." : "登録する"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/auth/components/RegisterPage.tsx
+++ b/frontend/src/features/auth/components/RegisterPage.tsx
@@ -1,0 +1,34 @@
+/**
+ * RegisterPage - 新規登録ページコンポーネント
+ * ルーティング対応のためのページラッパー
+ */
+import { useNavigate } from "react-router-dom";
+import { RegisterForm } from "./RegisterForm";
+
+/** RegisterPageコンポーネントのProps */
+export interface RegisterPageProps {
+  /** 登録成功時の遷移先URL */
+  redirectTo?: string;
+}
+
+/**
+ * RegisterPage - 新規登録ページ
+ * フルページレイアウトでRegisterFormを表示
+ */
+export function RegisterPage({ redirectTo = "/" }: RegisterPageProps) {
+  const navigate = useNavigate();
+
+  /**
+   * 登録成功時のハンドラ
+   * 指定されたパスへ遷移する
+   */
+  const handleSuccess = () => {
+    navigate(redirectTo);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <RegisterForm onSuccess={handleSuccess} />
+    </div>
+  );
+}

--- a/frontend/src/features/auth/components/index.ts
+++ b/frontend/src/features/auth/components/index.ts
@@ -1,0 +1,9 @@
+/**
+ * 認証コンポーネントのエクスポート
+ */
+
+export { RegisterForm } from "./RegisterForm";
+export type { RegisterFormProps } from "./RegisterForm";
+
+export { RegisterPage } from "./RegisterPage";
+export type { RegisterPageProps } from "./RegisterPage";

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -19,3 +19,7 @@ export { registerUser, ApiError } from "./api";
 // Hooks
 export { useRegisterUser } from "./hooks";
 export type { UseRegisterUserReturn } from "./hooks";
+
+// Components
+export { RegisterForm, RegisterPage } from "./components";
+export type { RegisterFormProps, RegisterPageProps } from "./components";

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,79 @@
+/**
+ * HomePage - ホームページコンポーネント
+ *
+ * 既存のApp.tsxの内容をページコンポーネントとして切り出し
+ */
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+/** ヘルスチェックのレスポンス型 */
+interface HealthStatus {
+  status: string;
+  message: string;
+}
+
+/**
+ * HomePage - ホームページ
+ *
+ * バックエンドのヘルスチェック機能を提供
+ */
+export function HomePage() {
+  const [health, setHealth] = useState<HealthStatus | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /**
+   * バックエンドのヘルスチェックを実行
+   */
+  const checkHealth = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch("http://localhost:8080/health");
+      const data = await response.json();
+      setHealth(data);
+    } catch (err) {
+      setError("Failed to connect to backend");
+      setHealth(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    checkHealth();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>CalTrack</CardTitle>
+          <CardDescription>Calorie tracking application</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="text-sm">
+            <p className="font-medium">Backend Status:</p>
+            {loading && <p className="text-muted-foreground">Checking...</p>}
+            {error && <p className="text-destructive">{error}</p>}
+            {health && (
+              <p className="text-green-600">
+                {health.status}: {health.message}
+              </p>
+            )}
+          </div>
+          <Button onClick={checkHealth} disabled={loading}>
+            {loading ? "Checking..." : "Check Backend Health"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/routes/RootLayout.tsx
+++ b/frontend/src/routes/RootLayout.tsx
@@ -1,0 +1,24 @@
+/**
+ * RootLayout - アプリケーション全体のレイアウトコンポーネント
+ *
+ * 将来的には共通ヘッダー、フッター、ナビゲーションなどを追加可能
+ */
+import { Outlet } from "react-router-dom";
+
+/**
+ * RootLayout - ルートレイアウト
+ *
+ * 全ページに共通のレイアウトを提供
+ * Outletで子ルートのコンテンツをレンダリング
+ */
+export function RootLayout() {
+  return (
+    <>
+      {/* 将来追加予定: <Header /> */}
+      <main>
+        <Outlet />
+      </main>
+      {/* 将来追加予定: <Footer /> */}
+    </>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,0 +1,51 @@
+/**
+ * ルーティング設定
+ * アプリケーション全体のルート定義を管理
+ *
+ * 将来の拡張に備えて、機能ごとにルートを分割可能な構成
+ */
+import { createBrowserRouter, RouteObject } from "react-router-dom";
+import { RootLayout } from "./RootLayout";
+import { HomePage } from "../pages/HomePage";
+import { RegisterPage } from "../features/auth/components/RegisterPage";
+
+/**
+ * 認証関連のルート定義
+ */
+const authRoutes: RouteObject[] = [
+  {
+    path: "/register",
+    element: <RegisterPage redirectTo="/" />,
+  },
+  // 将来追加予定:
+  // { path: "/login", element: <LoginPage /> },
+  // { path: "/forgot-password", element: <ForgotPasswordPage /> },
+];
+
+/**
+ * アプリケーションのメインルート定義
+ */
+const mainRoutes: RouteObject[] = [
+  {
+    path: "/",
+    element: <HomePage />,
+  },
+  // 将来追加予定:
+  // { path: "/dashboard", element: <DashboardPage /> },
+  // { path: "/meals", element: <MealsPage /> },
+];
+
+/**
+ * 全ルートをRootLayoutでラップ
+ */
+export const routes: RouteObject[] = [
+  {
+    element: <RootLayout />,
+    children: [...mainRoutes, ...authRoutes],
+  },
+];
+
+/**
+ * アプリケーションのルーター
+ */
+export const router = createBrowserRouter(routes);

--- a/frontend/src/routes/routes.test.tsx
+++ b/frontend/src/routes/routes.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ルーティングのテスト
+ *
+ * 各ルートが正しくレンダリングされることを確認
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createMemoryRouter, RouterProvider } from "react-router-dom";
+import { routes } from "./index";
+
+// fetchをモック化
+global.fetch = vi.fn(() =>
+  Promise.resolve({
+    json: () => Promise.resolve({ status: "healthy", message: "OK" }),
+  } as Response)
+);
+
+describe("ルーティング", () => {
+  describe("/register ルート", () => {
+    it("RegisterPageが表示される", async () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/register"],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      // RegisterFormのタイトルが表示されることを確認
+      expect(await screen.findByText("新規登録")).toBeInTheDocument();
+    });
+
+    it("登録フォームの主要フィールドが表示される", async () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/register"],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      // 主要なフォーム要素が表示されることを確認
+      expect(await screen.findByLabelText("メールアドレス")).toBeInTheDocument();
+      expect(screen.getByLabelText("パスワード")).toBeInTheDocument();
+      expect(screen.getByLabelText("ニックネーム")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "登録する" })).toBeInTheDocument();
+    });
+  });
+
+  describe("/ ルート", () => {
+    it("HomePageが表示される", async () => {
+      const router = createMemoryRouter(routes, {
+        initialEntries: ["/"],
+      });
+
+      render(<RouterProvider router={router} />);
+
+      // HomePageのタイトルが表示されることを確認
+      expect(await screen.findByText("CalTrack")).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- shadcn/uiコンポーネント追加（input, label, select）
- RegisterFormコンポーネント実装（バリデーション、useRegisterUser連携）
- RegisterPageコンポーネント実装
- React Router導入（react-router-dom v7）
- ルーティング構成（RootLayout, HomePage, RegisterPage）

## 関連Issue
- 設計Issue: #35
- 親Issue: #3

## 実装詳細
### UIコンポーネント
- `frontend/src/components/ui/input.tsx`
- `frontend/src/components/ui/label.tsx`
- `frontend/src/components/ui/select.tsx`

### 認証コンポーネント
- `frontend/src/features/auth/components/RegisterForm.tsx`: ユーザー登録フォーム本体
- `frontend/src/features/auth/components/RegisterPage.tsx`: 登録ページコンポーネント

### ルーティング
- `frontend/src/routes/index.tsx`: ルート定義
- `frontend/src/routes/RootLayout.tsx`: ルートレイアウト
- `frontend/src/pages/HomePage.tsx`: ホームページ

## Test plan
- [x] Build: Pass
- [x] Test: Pass (28 tests)
  - RegisterForm.test.tsx: 17件
  - routes.test.tsx: 3件
  - 既存テスト: 8件

🤖 Generated with [Claude Code](https://claude.com/claude-code)