### PR TITLE
feat(auth): 型定義とReact Best Practicesの改善

### DIFF
--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -3,7 +3,7 @@
  * 新規ユーザー登録のためのフォームUI
  */
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -19,13 +19,13 @@ import { useRegisterUser } from "../hooks";
 import type { Gender, ActivityLevel } from "../types";
 
 /** RegisterFormコンポーネントのProps */
-export interface RegisterFormProps {
+export type RegisterFormProps = {
   /** 登録成功時のコールバック */
   onSuccess?: () => void;
-}
+};
 
 /** フォームの内部状態 */
-interface FormState {
+type FormState = {
   email: string;
   password: string;
   nickname: string;
@@ -34,10 +34,10 @@ interface FormState {
   birthDate: string;
   gender: Gender | "";
   activityLevel: ActivityLevel | "";
-}
+};
 
 /** バリデーションエラー */
-interface FormErrors {
+type FormErrors = {
   email?: string;
   password?: string;
   nickname?: string;
@@ -46,7 +46,7 @@ interface FormErrors {
   birthDate?: string;
   gender?: string;
   activityLevel?: string;
-}
+};
 
 /** フォームの初期状態 */
 const initialFormState: FormState = {
@@ -76,6 +76,9 @@ const ACTIVITY_LEVEL_OPTIONS = [
   { value: "veryActive", label: "非常に活動的（毎日激しい運動）" },
 ] as const;
 
+/** メールアドレスバリデーション用パターン（モジュールレベルでホイスト） */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 /**
  * フォームバリデーション関数
  * @param form - フォームの状態
@@ -92,7 +95,7 @@ function validateForm(form: FormState): FormErrors {
   // email: 必須、形式チェック
   if (!form.email.trim()) {
     errors.email = "メールアドレスを入力してください";
-  } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email)) {
+  } else if (!EMAIL_PATTERN.test(form.email)) {
     errors.email = "正しいメールアドレス形式で入力してください";
   }
 
@@ -163,13 +166,6 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
   const [formErrors, setFormErrors] = useState<FormErrors>({});
   const { register, isLoading, error, isSuccess, reset } = useRegisterUser();
 
-  // 成功時にコールバックを呼び出す
-  useEffect(() => {
-    if (isSuccess) {
-      onSuccess?.();
-    }
-  }, [isSuccess, onSuccess]);
-
   /**
    * フィールド値の変更ハンドラ
    */
@@ -201,17 +197,20 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
       return;
     }
 
-    // API呼び出し
-    await register({
-      email: formState.email,
-      password: formState.password,
-      nickname: formState.nickname,
-      weight: parseFloat(formState.weight),
-      height: parseFloat(formState.height),
-      birthDate: formState.birthDate,
-      gender: formState.gender as Gender,
-      activityLevel: formState.activityLevel as ActivityLevel,
-    });
+    // API呼び出し（成功時のコールバックを引数として渡す）
+    await register(
+      {
+        email: formState.email,
+        password: formState.password,
+        nickname: formState.nickname,
+        weight: parseFloat(formState.weight),
+        height: parseFloat(formState.height),
+        birthDate: formState.birthDate,
+        gender: formState.gender as Gender,
+        activityLevel: formState.activityLevel as ActivityLevel,
+      },
+      onSuccess
+    );
   };
 
   return (

--- a/frontend/src/features/auth/components/RegisterPage.tsx
+++ b/frontend/src/features/auth/components/RegisterPage.tsx
@@ -6,10 +6,10 @@ import { useNavigate } from "react-router-dom";
 import { RegisterForm } from "./RegisterForm";
 
 /** RegisterPageコンポーネントのProps */
-export interface RegisterPageProps {
+export type RegisterPageProps = {
   /** 登録成功時の遷移先URL */
   redirectTo?: string;
-}
+};
 
 /**
  * RegisterPage - 新規登録ページ

--- a/frontend/src/features/auth/hooks/index.ts
+++ b/frontend/src/features/auth/hooks/index.ts
@@ -14,13 +14,13 @@ import {
 /**
  * useRegisterUserフックの戻り値の型
  */
-export interface UseRegisterUserReturn {
-  register: (request: RegisterUserRequest) => Promise<void>;
+export type UseRegisterUserReturn = {
+  register: (request: RegisterUserRequest, onSuccess?: () => void) => Promise<void>;
   isLoading: boolean;
   error: ApiError | null;
   isSuccess: boolean;
   reset: () => void;
-}
+};
 
 /**
  * ユーザー登録フック
@@ -42,7 +42,10 @@ export function useRegisterUser(): UseRegisterUserReturn {
   const [error, setError] = useState<ApiError | null>(null);
   const [isSuccess, setIsSuccess] = useState(false);
 
-  const register = useCallback(async (request: RegisterUserRequest) => {
+  const register = useCallback(async (
+    request: RegisterUserRequest,
+    onSuccess?: () => void
+  ) => {
     setIsLoading(true);
     setError(null);
     setIsSuccess(false);
@@ -50,6 +53,8 @@ export function useRegisterUser(): UseRegisterUserReturn {
     try {
       await registerUser(request);
       setIsSuccess(true);
+      // 成功時にコールバックを直接呼び出し
+      onSuccess?.();
     } catch (err) {
       if (err instanceof ApiError) {
         setError(err);

--- a/frontend/src/features/auth/types/index.ts
+++ b/frontend/src/features/auth/types/index.ts
@@ -28,7 +28,7 @@ export const ERROR_CODE_INTERNAL_ERROR: ErrorCode = "INTERNAL_ERROR";
 export const ERROR_MESSAGE_UNEXPECTED = "予期しないエラーが発生しました";
 
 /** ユーザー登録リクエスト */
-export interface RegisterUserRequest {
+export type RegisterUserRequest = {
   email: string;
   password: string;
   nickname: string;
@@ -37,16 +37,16 @@ export interface RegisterUserRequest {
   birthDate: string; // YYYY-MM-DD形式
   gender: Gender;
   activityLevel: ActivityLevel;
-}
+};
 
 /** ユーザー登録レスポンス */
-export interface RegisterUserResponse {
+export type RegisterUserResponse = {
   userId: string;
-}
+};
 
 /** APIエラーレスポンス */
-export interface ApiErrorResponse {
+export type ApiErrorResponse = {
   code: ErrorCode;
   message: string;
   details?: string[];
-}
+};

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -14,10 +14,10 @@ import {
 } from "@/components/ui/card";
 
 /** ヘルスチェックのレスポンス型 */
-interface HealthStatus {
+type HealthStatus = {
   status: string;
   message: string;
-}
+};
 
 /**
  * HomePage - ホームページ


### PR DESCRIPTION
## Summary
- `interface` を `type` に変更（9箇所）
- EMAIL_PATTERNをモジュールレベルにホイスト（re-render回避）
- register関数にonSuccessコールバック引数を追加（useEffect削除）
- テストを新しいAPI仕様に合わせて更新

## Test plan
- [x] Build: Pass
- [x] Test: Pass (10 tests)
- [x] Lint: Pass

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)