### PR TITLE
feat(vo): SessionID, ExpiresAt VOの実装

### DIFF
--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -3,14 +3,14 @@ package errors
 import "errors"
 
 var (
-	ErrEmailRequired       = errors.New("email is required")
-	ErrInvalidEmailFormat  = errors.New("invalid email format")
-	ErrEmailTooLong        = errors.New("email must be 254 characters or less")
-	ErrInvalidUserID       = errors.New("invalid user id: must be a valid UUID")
-	ErrPasswordRequired    = errors.New("password is required")
-	ErrPasswordTooShort    = errors.New("password must be at least 8 characters")
-	ErrNicknameRequired    = errors.New("nickname is required")
-	ErrNicknameTooLong     = errors.New("nickname must be 50 characters or less")
+	ErrEmailRequired        = errors.New("email is required")
+	ErrInvalidEmailFormat   = errors.New("invalid email format")
+	ErrEmailTooLong         = errors.New("email must be 254 characters or less")
+	ErrInvalidUserID        = errors.New("invalid user id: must be a valid UUID")
+	ErrPasswordRequired     = errors.New("password is required")
+	ErrPasswordTooShort     = errors.New("password must be at least 8 characters")
+	ErrNicknameRequired     = errors.New("nickname is required")
+	ErrNicknameTooLong      = errors.New("nickname must be 50 characters or less")
 	ErrWeightMustBePositive = errors.New("weight must be positive")
 	ErrWeightTooHeavy       = errors.New("weight must be 500kg or less")
 	ErrHeightMustBePositive = errors.New("height must be positive")
@@ -22,4 +22,9 @@ var (
 
 	// Usecase errors
 	ErrEmailAlreadyExists = errors.New("email already exists")
+
+	// Session errors
+	ErrSessionIDGenerationFailed = errors.New("failed to generate session id")
+	ErrInvalidSessionID          = errors.New("invalid session id")
+	ErrSessionExpired            = errors.New("session has expired")
 )

--- a/backend/domain/vo/expires_at.go
+++ b/backend/domain/vo/expires_at.go
@@ -1,0 +1,44 @@
+package vo
+
+import (
+	"time"
+
+	domainErrors "caltrack/domain/errors"
+)
+
+// セッションの有効期間（7日間）
+const SessionDurationDays = 7
+
+// ExpiresAt はセッションの有効期限を表す
+type ExpiresAt struct {
+	value time.Time
+}
+
+// NewExpiresAt は現在時刻から7日後の有効期限を生成する
+func NewExpiresAt() ExpiresAt {
+	expiresAt := nowFunc().AddDate(0, 0, SessionDurationDays)
+	return ExpiresAt{value: expiresAt}
+}
+
+// ParseExpiresAt は時刻からExpiresAtを復元する（DBからの復元用）
+func ParseExpiresAt(t time.Time) ExpiresAt {
+	return ExpiresAt{value: t}
+}
+
+// Time は有効期限のtime.Time表現を返す
+func (e ExpiresAt) Time() time.Time {
+	return e.value
+}
+
+// IsExpired は有効期限が過ぎているか判定する
+func (e ExpiresAt) IsExpired() bool {
+	return nowFunc().After(e.value)
+}
+
+// ValidateNotExpired は有効期限内かどうかを検証する
+func (e ExpiresAt) ValidateNotExpired() error {
+	if e.IsExpired() {
+		return domainErrors.ErrSessionExpired
+	}
+	return nil
+}

--- a/backend/domain/vo/expires_at_test.go
+++ b/backend/domain/vo/expires_at_test.go
@@ -1,0 +1,88 @@
+package vo
+
+import (
+	"testing"
+	"time"
+
+	domainErrors "caltrack/domain/errors"
+)
+
+func TestNewExpiresAt(t *testing.T) {
+	// 現在時刻を固定
+	fixedNow := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return fixedNow }
+	defer func() { nowFunc = time.Now }()
+
+	expiresAt := NewExpiresAt()
+
+	// 7日後であることを確認
+	expected := fixedNow.AddDate(0, 0, 7)
+	if !expiresAt.Time().Equal(expected) {
+		t.Errorf("NewExpiresAt().Time() = %v, want %v", expiresAt.Time(), expected)
+	}
+}
+
+func TestParseExpiresAt(t *testing.T) {
+	input := time.Date(2024, 6, 22, 12, 0, 0, 0, time.UTC)
+	expiresAt := ParseExpiresAt(input)
+
+	if !expiresAt.Time().Equal(input) {
+		t.Errorf("ParseExpiresAt(%v).Time() = %v, want %v", input, expiresAt.Time(), input)
+	}
+}
+
+func TestExpiresAt_IsExpired(t *testing.T) {
+	// 現在時刻を固定
+	fixedNow := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return fixedNow }
+	defer func() { nowFunc = time.Now }()
+
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		// 有効期限内
+		{"future", fixedNow.Add(1 * time.Hour), false},
+		{"exactly now", fixedNow, false},
+		// 有効期限切れ
+		{"past by 1 second", fixedNow.Add(-1 * time.Second), true},
+		{"past by 1 day", fixedNow.AddDate(0, 0, -1), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := ParseExpiresAt(tt.expiresAt)
+			if got := e.IsExpired(); got != tt.want {
+				t.Errorf("IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpiresAt_ValidateNotExpired(t *testing.T) {
+	// 現在時刻を固定
+	fixedNow := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	nowFunc = func() time.Time { return fixedNow }
+	defer func() { nowFunc = time.Now }()
+
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		wantErr   error
+	}{
+		// 有効期限内
+		{"valid", fixedNow.Add(1 * time.Hour), nil},
+		// 有効期限切れ
+		{"expired", fixedNow.Add(-1 * time.Second), domainErrors.ErrSessionExpired},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := ParseExpiresAt(tt.expiresAt)
+			if err := e.ValidateNotExpired(); err != tt.wantErr {
+				t.Errorf("ValidateNotExpired() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/backend/domain/vo/session_id.go
+++ b/backend/domain/vo/session_id.go
@@ -1,0 +1,55 @@
+package vo
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+
+	domainErrors "caltrack/domain/errors"
+)
+
+// セッションIDの長さ（バイト数）
+// 32バイト = 256ビットのエントロピー
+const sessionIDBytes = 32
+
+// SessionID はセッションを識別するランダムな文字列
+type SessionID struct {
+	value string
+}
+
+// NewSessionID は新しいセッションIDを生成する
+func NewSessionID() (SessionID, error) {
+	bytes := make([]byte, sessionIDBytes)
+	if _, err := rand.Read(bytes); err != nil {
+		return SessionID{}, domainErrors.ErrSessionIDGenerationFailed
+	}
+	// URL-safe Base64エンコード
+	value := base64.URLEncoding.EncodeToString(bytes)
+	return SessionID{value: value}, nil
+}
+
+// ParseSessionID は文字列からSessionIDを復元する
+func ParseSessionID(value string) (SessionID, error) {
+	if value == "" {
+		return SessionID{}, domainErrors.ErrInvalidSessionID
+	}
+	// Base64デコードで妥当性を検証
+	decoded, err := base64.URLEncoding.DecodeString(value)
+	if err != nil {
+		return SessionID{}, domainErrors.ErrInvalidSessionID
+	}
+	// 長さの検証
+	if len(decoded) != sessionIDBytes {
+		return SessionID{}, domainErrors.ErrInvalidSessionID
+	}
+	return SessionID{value: value}, nil
+}
+
+// String はセッションIDの文字列表現を返す
+func (s SessionID) String() string {
+	return s.value
+}
+
+// Equals は2つのセッションIDが等しいか比較する
+func (s SessionID) Equals(other SessionID) bool {
+	return s.value == other.value
+}

--- a/backend/domain/vo/session_id_test.go
+++ b/backend/domain/vo/session_id_test.go
@@ -1,0 +1,90 @@
+package vo_test
+
+import (
+	"testing"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+)
+
+func TestNewSessionID(t *testing.T) {
+	sessionID, err := vo.NewSessionID()
+
+	if err != nil {
+		t.Fatalf("NewSessionID() error = %v, want nil", err)
+	}
+	if sessionID.String() == "" {
+		t.Error("NewSessionID() should return non-empty string")
+	}
+}
+
+func TestNewSessionID_Uniqueness(t *testing.T) {
+	// 複数回生成して重複しないことを確認
+	ids := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id, err := vo.NewSessionID()
+		if err != nil {
+			t.Fatalf("NewSessionID() error = %v", err)
+		}
+		if ids[id.String()] {
+			t.Errorf("NewSessionID() generated duplicate ID: %s", id.String())
+		}
+		ids[id.String()] = true
+	}
+}
+
+func TestParseSessionID(t *testing.T) {
+	// 有効なセッションIDを生成
+	validID, _ := vo.NewSessionID()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		// 正常系
+		{"valid session id", validID.String(), nil},
+		// 異常系
+		{"empty string", "", domainErrors.ErrInvalidSessionID},
+		{"invalid base64", "not-valid-base64!!!", domainErrors.ErrInvalidSessionID},
+		{"too short", "YWJjZA==", domainErrors.ErrInvalidSessionID}, // "abcd" in base64
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vo.ParseSessionID(tt.input)
+
+			if err != tt.wantErr {
+				t.Errorf("ParseSessionID(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if err == nil && got.String() != tt.input {
+				t.Errorf("ParseSessionID(%q).String() = %v, want %v", tt.input, got.String(), tt.input)
+			}
+		})
+	}
+}
+
+func TestSessionID_Equals(t *testing.T) {
+	id1, _ := vo.NewSessionID()
+	id2, _ := vo.ParseSessionID(id1.String())
+	id3, _ := vo.NewSessionID()
+
+	tests := []struct {
+		name string
+		id1  vo.SessionID
+		id2  vo.SessionID
+		want bool
+	}{
+		{"same value", id1, id2, true},
+		{"different value", id1, id3, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id1.Equals(tt.id2); got != tt.want {
+				t.Errorf("Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- SessionID: 暗号学的に安全な乱数生成（32バイト、URL-safe Base64）
- ExpiresAt: セッション有効期限管理（7日間）
- エラー定義追加: ErrSessionIDGenerationFailed, ErrInvalidSessionID, ErrSessionExpired

## Test plan
- [x] Build: Pass
- [x] Test: Pass (16 tests)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)