### PR TITLE
feat(entity): Session Entityの実装

### DIFF
--- a/backend/domain/entity/session.go
+++ b/backend/domain/entity/session.go
@@ -1,0 +1,123 @@
+package entity
+
+import (
+	"time"
+
+	"caltrack/domain/vo"
+)
+
+// Session はユーザーセッションを表すエンティティ
+type Session struct {
+	id        vo.SessionID
+	userID    vo.UserID
+	expiresAt vo.ExpiresAt
+	createdAt time.Time
+}
+
+// NewSession は新しいセッションを生成する
+// userIDStr: ユーザーID文字列
+// 戻り値: 生成されたSession, エラースライス
+func NewSession(userIDStr string) (*Session, []error) {
+	var errs []error
+
+	userID, err := parseUserID(userIDStr)
+	errs = appendIfErr(errs, err)
+
+	sessionID, err := parseSessionID()
+	errs = appendIfErr(errs, err)
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return &Session{
+		id:        sessionID,
+		userID:    userID,
+		expiresAt: vo.NewExpiresAt(),
+		createdAt: time.Now(),
+	}, nil
+}
+
+// NewSessionWithUserID はUserID VOから新しいセッションを生成する
+// 既にUserID VOを持っている場合に使用（認証後など）
+func NewSessionWithUserID(userID vo.UserID) (*Session, error) {
+	sessionID, err := vo.NewSessionID()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Session{
+		id:        sessionID,
+		userID:    userID,
+		expiresAt: vo.NewExpiresAt(),
+		createdAt: time.Now(),
+	}, nil
+}
+
+// ReconstructSession はDBからの復元用
+// NOTE: DBデータは保存時にバリデーション済みなのでVO変換は本来不要だが、
+// データ破損検知のため一旦バリデーションありで実装。
+func ReconstructSession(
+	sessionIDStr string,
+	userIDStr string,
+	expiresAt time.Time,
+	createdAt time.Time,
+) (*Session, error) {
+	sessionID, err := vo.ParseSessionID(sessionIDStr)
+	if err != nil {
+		return nil, err
+	}
+
+	userID, err := vo.ParseUserID(userIDStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Session{
+		id:        sessionID,
+		userID:    userID,
+		expiresAt: vo.ParseExpiresAt(expiresAt),
+		createdAt: createdAt,
+	}, nil
+}
+
+// parseUserID はUserID文字列をVOに変換する
+func parseUserID(s string) (vo.UserID, error) {
+	return vo.ParseUserID(s)
+}
+
+// parseSessionID は新しいSessionIDを生成する
+func parseSessionID() (vo.SessionID, error) {
+	return vo.NewSessionID()
+}
+
+// ID はセッションIDを返す
+func (s *Session) ID() vo.SessionID {
+	return s.id
+}
+
+// UserID はユーザーIDを返す
+func (s *Session) UserID() vo.UserID {
+	return s.userID
+}
+
+// ExpiresAt は有効期限を返す
+func (s *Session) ExpiresAt() vo.ExpiresAt {
+	return s.expiresAt
+}
+
+// CreatedAt は作成日時を返す
+func (s *Session) CreatedAt() time.Time {
+	return s.createdAt
+}
+
+// IsExpired はセッションが有効期限切れかどうかを返す
+func (s *Session) IsExpired() bool {
+	return s.expiresAt.IsExpired()
+}
+
+// ValidateNotExpired はセッションが有効期限内かどうかを検証する
+// 有効期限切れの場合は ErrSessionExpired を返す
+func (s *Session) ValidateNotExpired() error {
+	return s.expiresAt.ValidateNotExpired()
+}

--- a/backend/domain/entity/session_test.go
+++ b/backend/domain/entity/session_test.go
@@ -1,0 +1,258 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+)
+
+func TestNewSession_Success(t *testing.T) {
+	validUserID := "550e8400-e29b-41d4-a716-446655440000"
+
+	session, errs := entity.NewSession(validUserID)
+
+	if errs != nil {
+		t.Fatalf("NewSession() unexpected errors: %v", errs)
+	}
+	if session.ID().String() == "" {
+		t.Error("ID should not be empty")
+	}
+	if session.UserID().String() != validUserID {
+		t.Errorf("UserID = %v, want %v", session.UserID().String(), validUserID)
+	}
+	if session.ExpiresAt().Time().IsZero() {
+		t.Error("ExpiresAt should not be zero")
+	}
+	if session.CreatedAt().IsZero() {
+		t.Error("CreatedAt should not be zero")
+	}
+}
+
+func TestNewSession_InvalidUserID(t *testing.T) {
+	tests := []struct {
+		name    string
+		userID  string
+		wantErr error
+	}{
+		{"empty user id", "", domainErrors.ErrInvalidUserID},
+		{"invalid uuid format", "invalid-uuid", domainErrors.ErrInvalidUserID},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := entity.NewSession(tt.userID)
+
+			if len(errs) != 1 {
+				t.Fatalf("got %d errors, want 1: %v", len(errs), errs)
+			}
+			if errs[0] != tt.wantErr {
+				t.Errorf("got err = %v, want %v", errs[0], tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewSession_GeneratesUniqueIDs(t *testing.T) {
+	validUserID := "550e8400-e29b-41d4-a716-446655440000"
+
+	session1, _ := entity.NewSession(validUserID)
+	session2, _ := entity.NewSession(validUserID)
+
+	if session1.ID().Equals(session2.ID()) {
+		t.Error("should generate unique session IDs")
+	}
+}
+
+func TestNewSessionWithUserID_Success(t *testing.T) {
+	userID, _ := vo.ParseUserID("550e8400-e29b-41d4-a716-446655440000")
+
+	session, err := entity.NewSessionWithUserID(userID)
+
+	if err != nil {
+		t.Fatalf("NewSessionWithUserID() unexpected error: %v", err)
+	}
+	if session.ID().String() == "" {
+		t.Error("ID should not be empty")
+	}
+	if !session.UserID().Equals(userID) {
+		t.Errorf("UserID = %v, want %v", session.UserID().String(), userID.String())
+	}
+	if session.ExpiresAt().Time().IsZero() {
+		t.Error("ExpiresAt should not be zero")
+	}
+	if session.CreatedAt().IsZero() {
+		t.Error("CreatedAt should not be zero")
+	}
+}
+
+func TestNewSessionWithUserID_GeneratesUniqueIDs(t *testing.T) {
+	userID, _ := vo.ParseUserID("550e8400-e29b-41d4-a716-446655440000")
+
+	session1, _ := entity.NewSessionWithUserID(userID)
+	session2, _ := entity.NewSessionWithUserID(userID)
+
+	if session1.ID().Equals(session2.ID()) {
+		t.Error("should generate unique session IDs")
+	}
+}
+
+func TestReconstructSession_Success(t *testing.T) {
+	// 有効なセッションIDを生成してそのString表現を使用
+	validSessionID, _ := vo.NewSessionID()
+	sessionIDStr := validSessionID.String()
+	userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+	expiresAt := time.Date(2024, 6, 22, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	session, err := entity.ReconstructSession(
+		sessionIDStr,
+		userIDStr,
+		expiresAt,
+		createdAt,
+	)
+
+	if err != nil {
+		t.Fatalf("ReconstructSession() unexpected error: %v", err)
+	}
+	if session.ID().String() != sessionIDStr {
+		t.Errorf("ID = %v, want %v", session.ID().String(), sessionIDStr)
+	}
+	if session.UserID().String() != userIDStr {
+		t.Errorf("UserID = %v, want %v", session.UserID().String(), userIDStr)
+	}
+	if !session.ExpiresAt().Time().Equal(expiresAt) {
+		t.Errorf("ExpiresAt = %v, want %v", session.ExpiresAt().Time(), expiresAt)
+	}
+	if !session.CreatedAt().Equal(createdAt) {
+		t.Errorf("CreatedAt = %v, want %v", session.CreatedAt(), createdAt)
+	}
+}
+
+func TestReconstructSession_InvalidSessionID(t *testing.T) {
+	userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+	expiresAt := time.Date(2024, 6, 22, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		sessionID string
+	}{
+		{"empty session id", ""},
+		{"invalid base64", "not-valid-base64!!!"},
+		{"too short base64", "YWJjZA=="},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := entity.ReconstructSession(
+				tt.sessionID,
+				userIDStr,
+				expiresAt,
+				createdAt,
+			)
+
+			if err != domainErrors.ErrInvalidSessionID {
+				t.Errorf("got err = %v, want %v", err, domainErrors.ErrInvalidSessionID)
+			}
+		})
+	}
+}
+
+func TestReconstructSession_InvalidUserID(t *testing.T) {
+	validSessionID, _ := vo.NewSessionID()
+	sessionIDStr := validSessionID.String()
+	expiresAt := time.Date(2024, 6, 22, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		userID string
+	}{
+		{"empty user id", ""},
+		{"invalid uuid format", "invalid-uuid"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := entity.ReconstructSession(
+				sessionIDStr,
+				tt.userID,
+				expiresAt,
+				createdAt,
+			)
+
+			if err != domainErrors.ErrInvalidUserID {
+				t.Errorf("got err = %v, want %v", err, domainErrors.ErrInvalidUserID)
+			}
+		})
+	}
+}
+
+func TestSession_IsExpired(t *testing.T) {
+	validSessionID, _ := vo.NewSessionID()
+	sessionIDStr := validSessionID.String()
+	userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+	createdAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		want      bool
+	}{
+		// 有効期限内（未来）
+		{"not expired", time.Now().Add(24 * time.Hour), false},
+		// 有効期限切れ（過去）
+		{"expired", time.Now().Add(-24 * time.Hour), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, _ := entity.ReconstructSession(
+				sessionIDStr,
+				userIDStr,
+				tt.expiresAt,
+				createdAt,
+			)
+
+			if got := session.IsExpired(); got != tt.want {
+				t.Errorf("IsExpired() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSession_ValidateNotExpired(t *testing.T) {
+	validSessionID, _ := vo.NewSessionID()
+	sessionIDStr := validSessionID.String()
+	userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+	createdAt := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		expiresAt time.Time
+		wantErr   error
+	}{
+		// 有効期限内（未来）
+		{"valid", time.Now().Add(24 * time.Hour), nil},
+		// 有効期限切れ（過去）
+		{"expired", time.Now().Add(-24 * time.Hour), domainErrors.ErrSessionExpired},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, _ := entity.ReconstructSession(
+				sessionIDStr,
+				userIDStr,
+				tt.expiresAt,
+				createdAt,
+			)
+
+			if err := session.ValidateNotExpired(); err != tt.wantErr {
+				t.Errorf("ValidateNotExpired() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Session Entity構造体と各種ファクトリ関数の実装
- NewSession: プリミティブ型からの生成（エラー集約対応）
- NewSessionWithUserID: UserID VOからの生成（認証後の利用想定）
- ReconstructSession: DB復元用（バリデーションあり）
- IsExpired, ValidateNotExpired メソッドの実装

## Test plan
- [x] Build: Pass
- [x] Test: Pass (12 tests)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)