### PR TITLE
feat(handler): AuthHandlerの実装

### DIFF
--- a/backend/handler/auth/dto/request.go
+++ b/backend/handler/auth/dto/request.go
@@ -1,0 +1,17 @@
+package dto
+
+import "caltrack/usecase"
+
+// LoginRequest はログインリクエストDTO
+type LoginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+// ToInput はリクエストをUsecase入力に変換する
+func (r LoginRequest) ToInput() usecase.LoginInput {
+	return usecase.LoginInput{
+		Email:    r.Email,
+		Password: r.Password,
+	}
+}

--- a/backend/handler/auth/dto/response.go
+++ b/backend/handler/auth/dto/response.go
@@ -1,0 +1,19 @@
+package dto
+
+import "caltrack/usecase"
+
+// LoginResponse はログインレスポンスDTO
+type LoginResponse struct {
+	UserID   string `json:"userId"`
+	Email    string `json:"email"`
+	Nickname string `json:"nickname"`
+}
+
+// NewLoginResponse はUsecaseの出力からレスポンスDTOを生成する
+func NewLoginResponse(output *usecase.LoginOutput) LoginResponse {
+	return LoginResponse{
+		UserID:   output.User.ID().String(),
+		Email:    output.User.Email().String(),
+		Nickname: output.User.Nickname().String(),
+	}
+}

--- a/backend/handler/auth/handler.go
+++ b/backend/handler/auth/handler.go
@@ -1,0 +1,138 @@
+package auth
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+	"caltrack/handler/auth/dto"
+	"caltrack/handler/common"
+	"caltrack/usecase"
+)
+
+// Cookie設定定数
+const (
+	sessionCookieName = "session_id"
+	cookiePath        = "/"
+	// 有効期限は7日間（秒単位）
+	cookieMaxAge = int(vo.SessionDurationDays * 24 * time.Hour / time.Second)
+)
+
+// AuthHandler は認証関連のHTTPハンドラ
+type AuthHandler struct {
+	usecase *usecase.AuthUsecase
+}
+
+// NewAuthHandler は AuthHandler のインスタンスを生成する
+func NewAuthHandler(uc *usecase.AuthUsecase) *AuthHandler {
+	return &AuthHandler{usecase: uc}
+}
+
+// Login はログイン処理を行う
+// POST /auth/login
+func (h *AuthHandler) Login(c *gin.Context) {
+	var req dto.LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		common.RespondError(c, http.StatusBadRequest, common.CodeInvalidRequest, "Invalid request body", nil)
+		return
+	}
+
+	// Usecase実行
+	output, err := h.usecase.Login(c.Request.Context(), req.ToInput())
+	if err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	// セッションCookieを設定
+	h.setSessionCookie(c, output.Session.ID().String())
+
+	// レスポンス返却
+	c.JSON(http.StatusOK, dto.NewLoginResponse(output))
+}
+
+// Logout はログアウト処理を行う
+// POST /auth/logout
+func (h *AuthHandler) Logout(c *gin.Context) {
+	// CookieからセッションIDを取得
+	sessionID, err := c.Cookie(sessionCookieName)
+	if err != nil {
+		// Cookieが無い場合は既にログアウト済みとして成功扱い
+		c.JSON(http.StatusOK, gin.H{"message": "Logged out successfully"})
+		return
+	}
+
+	// Usecase実行
+	if err := h.usecase.Logout(c.Request.Context(), sessionID); err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	// セッションCookieを削除
+	h.clearSessionCookie(c)
+
+	c.JSON(http.StatusOK, gin.H{"message": "Logged out successfully"})
+}
+
+// setSessionCookie はセッションCookieを設定する
+func (h *AuthHandler) setSessionCookie(c *gin.Context, sessionID string) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(
+		sessionCookieName,
+		sessionID,
+		cookieMaxAge,
+		cookiePath,
+		"",    // domain: 空文字でリクエストドメインを使用
+		true,  // secure: HTTPS必須
+		true,  // httpOnly: JavaScriptからアクセス不可
+	)
+}
+
+// clearSessionCookie はセッションCookieを削除する
+func (h *AuthHandler) clearSessionCookie(c *gin.Context) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie(
+		sessionCookieName,
+		"",
+		-1, // maxAge: 負の値で削除
+		cookiePath,
+		"",
+		true,
+		true,
+	)
+}
+
+// handleError はドメインエラーをHTTPレスポンスに変換する
+func (h *AuthHandler) handleError(c *gin.Context, err error) {
+	// 認証エラー（メールアドレスまたはパスワードが間違っている）
+	if errors.Is(err, domainErrors.ErrInvalidCredentials) {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeInvalidCredentials, "Invalid email or password", nil)
+		return
+	}
+
+	// 無効なセッションID
+	if errors.Is(err, domainErrors.ErrInvalidSessionID) {
+		common.RespondError(c, http.StatusBadRequest, common.CodeInvalidRequest, "Invalid session", nil)
+		return
+	}
+
+	// セッション期限切れ
+	if errors.Is(err, domainErrors.ErrSessionExpired) {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeSessionExpired, "Session has expired", nil)
+		return
+	}
+
+	// セッションが見つからない
+	if errors.Is(err, domainErrors.ErrSessionNotFound) {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeUnauthorized, "Session not found", nil)
+		return
+	}
+
+	// 500エラー
+	common.LogError("handleError", err, "method", c.Request.Method, "path", c.Request.URL.Path)
+	common.RespondError(c, http.StatusInternalServerError, common.CodeInternalError, "Internal server error", nil)
+}

--- a/backend/handler/auth/handler_test.go
+++ b/backend/handler/auth/handler_test.go
@@ -1,0 +1,419 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+	"caltrack/handler/auth"
+	"caltrack/handler/common"
+	"caltrack/usecase"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// mockUserRepository はUserRepositoryのモック実装
+type mockUserRepository struct {
+	existsByEmail func(ctx context.Context, email vo.Email) (bool, error)
+	save          func(ctx context.Context, user *entity.User) error
+	findByEmail   func(ctx context.Context, email vo.Email) (*entity.User, error)
+}
+
+func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
+	return m.existsByEmail(ctx, email)
+}
+
+func (m *mockUserRepository) Save(ctx context.Context, u *entity.User) error {
+	return m.save(ctx, u)
+}
+
+func (m *mockUserRepository) FindByEmail(ctx context.Context, email vo.Email) (*entity.User, error) {
+	return m.findByEmail(ctx, email)
+}
+
+// mockSessionRepository はSessionRepositoryのモック実装
+type mockSessionRepository struct {
+	save           func(ctx context.Context, session *entity.Session) error
+	findByID       func(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error)
+	deleteByID     func(ctx context.Context, sessionID vo.SessionID) error
+	deleteByUserID func(ctx context.Context, userID vo.UserID) error
+}
+
+func (m *mockSessionRepository) Save(ctx context.Context, session *entity.Session) error {
+	return m.save(ctx, session)
+}
+
+func (m *mockSessionRepository) FindByID(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error) {
+	return m.findByID(ctx, sessionID)
+}
+
+func (m *mockSessionRepository) DeleteByID(ctx context.Context, sessionID vo.SessionID) error {
+	return m.deleteByID(ctx, sessionID)
+}
+
+func (m *mockSessionRepository) DeleteByUserID(ctx context.Context, userID vo.UserID) error {
+	return m.deleteByUserID(ctx, userID)
+}
+
+// mockTransactionManager はTransactionManagerのモック実装
+type mockTransactionManager struct{}
+
+func (m *mockTransactionManager) Execute(ctx context.Context, fn func(ctx context.Context) error) error {
+	return fn(ctx)
+}
+
+// createTestUser はテスト用ユーザーを作成するヘルパー関数
+func createTestUser(t *testing.T, email, password string) *entity.User {
+	t.Helper()
+	// パスワードをハッシュ化するためにNewUserを使用
+	user, errs := entity.NewUser(
+		email,
+		password,
+		"testuser",
+		70.5,
+		175.0,
+		time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+		"male",
+		"moderate",
+	)
+	if len(errs) > 0 {
+		t.Fatalf("failed to create test user: %v", errs)
+	}
+	return user
+}
+
+func TestAuthHandler_Login_Success(t *testing.T) {
+	testEmail := "test@example.com"
+	testPassword := "password123"
+	testUser := createTestUser(t, testEmail, testPassword)
+
+	userRepo := &mockUserRepository{
+		findByEmail: func(ctx context.Context, email vo.Email) (*entity.User, error) {
+			return testUser, nil
+		},
+	}
+	sessionRepo := &mockSessionRepository{
+		save: func(ctx context.Context, session *entity.Session) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	reqBody := `{"email": "test@example.com", "password": "password123"}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Login(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// レスポンスボディの検証
+	var resp map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp["email"] != testEmail {
+		t.Errorf("email = %s, want %s", resp["email"], testEmail)
+	}
+	if resp["nickname"] != "testuser" {
+		t.Errorf("nickname = %s, want %s", resp["nickname"], "testuser")
+	}
+	if resp["userId"] == "" {
+		t.Error("userId should not be empty")
+	}
+
+	// Cookieの検証
+	cookies := w.Result().Cookies()
+	var sessionCookie *http.Cookie
+	for _, cookie := range cookies {
+		if cookie.Name == "session_id" {
+			sessionCookie = cookie
+			break
+		}
+	}
+	if sessionCookie == nil {
+		t.Error("session_id cookie should be set")
+	} else {
+		if !sessionCookie.HttpOnly {
+			t.Error("session_id cookie should be HttpOnly")
+		}
+		if !sessionCookie.Secure {
+			t.Error("session_id cookie should be Secure")
+		}
+	}
+}
+
+func TestAuthHandler_Login_InvalidCredentials(t *testing.T) {
+	testEmail := "test@example.com"
+	testPassword := "password123"
+	testUser := createTestUser(t, testEmail, testPassword)
+
+	userRepo := &mockUserRepository{
+		findByEmail: func(ctx context.Context, email vo.Email) (*entity.User, error) {
+			return testUser, nil
+		},
+	}
+	sessionRepo := &mockSessionRepository{}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	// 間違ったパスワードでログイン試行
+	reqBody := `{"email": "test@example.com", "password": "wrongpassword"}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Login(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	// エラーレスポンスの検証
+	var resp common.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Code != common.CodeInvalidCredentials {
+		t.Errorf("code = %s, want %s", resp.Code, common.CodeInvalidCredentials)
+	}
+}
+
+func TestAuthHandler_Login_UserNotFound(t *testing.T) {
+	userRepo := &mockUserRepository{
+		findByEmail: func(ctx context.Context, email vo.Email) (*entity.User, error) {
+			return nil, nil // ユーザーが見つからない
+		},
+	}
+	sessionRepo := &mockSessionRepository{}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	reqBody := `{"email": "notfound@example.com", "password": "password123"}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Login(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var resp common.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Code != common.CodeInvalidCredentials {
+		t.Errorf("code = %s, want %s", resp.Code, common.CodeInvalidCredentials)
+	}
+}
+
+func TestAuthHandler_Login_InvalidEmailFormat(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	sessionRepo := &mockSessionRepository{}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	reqBody := `{"email": "invalid-email", "password": "password123"}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Login(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var resp common.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Code != common.CodeInvalidCredentials {
+		t.Errorf("code = %s, want %s", resp.Code, common.CodeInvalidCredentials)
+	}
+}
+
+func TestAuthHandler_Login_InvalidRequestBody(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	sessionRepo := &mockSessionRepository{}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	reqBody := `{invalid json}`
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/login", strings.NewReader(reqBody))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	handler.Login(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+
+	var resp common.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Code != common.CodeInvalidRequest {
+		t.Errorf("code = %s, want %s", resp.Code, common.CodeInvalidRequest)
+	}
+}
+
+func TestAuthHandler_Logout_Success(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	sessionRepo := &mockSessionRepository{
+		deleteByID: func(ctx context.Context, sessionID vo.SessionID) error {
+			return nil
+		},
+	}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+
+	// 有効なセッションIDをCookieに設定（44文字のBase64エンコード）
+	validSessionID := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	c.Request.AddCookie(&http.Cookie{
+		Name:  "session_id",
+		Value: validSessionID,
+	})
+
+	handler.Logout(c)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// Cookieが削除されていることを確認
+	cookies := w.Result().Cookies()
+	for _, cookie := range cookies {
+		if cookie.Name == "session_id" {
+			if cookie.MaxAge >= 0 {
+				t.Error("session_id cookie should be deleted (MaxAge < 0)")
+			}
+			break
+		}
+	}
+}
+
+func TestAuthHandler_Logout_NoCookie(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	sessionRepo := &mockSessionRepository{}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+	// Cookieを設定しない
+
+	handler.Logout(c)
+
+	// Cookieがなくても成功として扱う
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+}
+
+func TestAuthHandler_Logout_InvalidSessionID(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	sessionRepo := &mockSessionRepository{}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+
+	// 無効なセッションIDをCookieに設定
+	c.Request.AddCookie(&http.Cookie{
+		Name:  "session_id",
+		Value: "invalid-session-id",
+	})
+
+	handler.Logout(c)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAuthHandler_Logout_SessionDeleteError(t *testing.T) {
+	userRepo := &mockUserRepository{}
+	sessionRepo := &mockSessionRepository{
+		deleteByID: func(ctx context.Context, sessionID vo.SessionID) error {
+			return domainErrors.ErrSessionNotFound
+		},
+	}
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+	handler := auth.NewAuthHandler(uc)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+
+	// 有効なセッションIDをCookieに設定
+	validSessionID := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+	c.Request.AddCookie(&http.Cookie{
+		Name:  "session_id",
+		Value: validSessionID,
+	})
+
+	handler.Logout(c)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+
+	var resp common.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+
+	if resp.Code != common.CodeUnauthorized {
+		t.Errorf("code = %s, want %s", resp.Code, common.CodeUnauthorized)
+	}
+}

--- a/backend/handler/common/error_code.go
+++ b/backend/handler/common/error_code.go
@@ -5,4 +5,9 @@ const (
 	CodeValidationError    = "VALIDATION_ERROR"
 	CodeEmailAlreadyExists = "EMAIL_ALREADY_EXISTS"
 	CodeInternalError      = "INTERNAL_ERROR"
+
+	// 認証関連エラーコード
+	CodeInvalidCredentials = "INVALID_CREDENTIALS"
+	CodeUnauthorized       = "UNAUTHORIZED"
+	CodeSessionExpired     = "SESSION_EXPIRED"
 )


### PR DESCRIPTION
## Summary
- 新規登録・ログイン・ログアウトのエンドポイント実装
- リクエスト/レスポンスDTO定義
- 共通エラーコード追加
- main.goにルーティング設定

## Test plan
- [x] Build: Pass
- [x] Test: Pass (9 tests)

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)