### PR TITLE
feat: frontend-designスキル追加とRegisterPageデザイン改善

### DIFF
--- a/.claude/skills/frontend-design.md
+++ b/.claude/skills/frontend-design.md
@@ -1,0 +1,683 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use when building UI components, designing layouts, or when asked to "make it look good", "improve the design", or "create a unique UI".
+metadata:
+  author: CalTrack
+  version: "1.0.0"
+---
+
+# Frontend Design Guidelines
+
+汎用的なAI生成デザインを避け、独特で記憶に残るUIを作成するためのガイドライン。
+
+## 技術スタック
+
+- React + TypeScript + Vite
+- shadcn/ui
+- Tailwind CSS
+
+---
+
+## 1. Design Thinking Process
+
+UIを作成する前に、以下の4つの質問に答えること。
+
+### 1.1 Purpose（目的）
+
+このインターフェースが解決する問題は何か？
+
+```
+// 悪い例: 目的が曖昧
+「ユーザーがデータを見れるようにする」
+
+// 良い例: 明確な目的
+「ユーザーが今日の摂取カロリーを一目で把握し、
+ 目標との差分を直感的に理解できるようにする」
+```
+
+### 1.2 Tone（トーン・美的方向性）
+
+どのような美的方向性を目指すか？極端な方向性を選ぶこと。
+
+| トーン | 特徴 | 使用例 |
+|--------|------|--------|
+| Brutally Minimal | 余白多め、要素最小限、タイポグラフィ重視 | ダッシュボード、設定画面 |
+| Maximalist Chaos | 情報密度高、レイヤー多重、視覚的刺激 | ランディングページ、プロモーション |
+| Retro-Futuristic | レトロ要素 + 未来的要素の融合 | ブランディング重視の画面 |
+| Warm & Organic | 丸み、暖色、手書き風要素 | オンボーディング、ヘルス系 |
+| Dark & Precise | ダークテーマ、シャープなエッジ、高コントラスト | データ可視化、プロ向け |
+
+### 1.3 Constraints（技術的制約）
+
+考慮すべき技術的要件をリストアップする。
+
+- レスポンシブ対応の範囲（モバイルファースト？）
+- アクセシビリティ要件（WCAG レベル）
+- パフォーマンス制約（アニメーション可否）
+- ブラウザサポート範囲
+
+### 1.4 Differentiation（差別化要素）
+
+何がこのUIを忘れられないものにするか？
+
+```
+// 悪い例: 差別化なし
+「きれいなカードレイアウト」
+
+// 良い例: 明確な差別化
+「カロリーを"貯金"に見立てた金庫モチーフのプログレスバー、
+ 食事記録時の硬貨投入アニメーション」
+```
+
+---
+
+## 2. Typography Guidelines
+
+### 2.1 避けるべきフォント
+
+以下のフォントは汎用的すぎるため使用を避ける。
+
+```css
+/* 禁止フォント */
+font-family: Inter;        /* 使い古された */
+font-family: Roboto;       /* 汎用的すぎる */
+font-family: Arial;        /* デフォルト感 */
+font-family: Helvetica;    /* 無個性 */
+font-family: Open Sans;    /* 見慣れすぎ */
+font-family: system-ui;    /* 差別化不可 */
+```
+
+### 2.2 推奨フォントの選び方
+
+目的に応じたフォント選択指針。
+
+| 用途 | 推奨カテゴリ | 例 |
+|------|-------------|-----|
+| 見出し | Display / Decorative | Playfair Display, Space Grotesk, Clash Display |
+| 本文 | Readable Sans | DM Sans, Plus Jakarta Sans, Outfit |
+| 数値 | Monospace / Tabular | JetBrains Mono, IBM Plex Mono, Fira Code |
+| アクセント | Variable / Experimental | Instrument Sans, Satoshi, General Sans |
+
+### 2.3 実装例
+
+```tsx
+// tailwind.config.ts でのフォント設定
+import { fontFamily } from "tailwindcss/defaultTheme";
+
+export default {
+  theme: {
+    extend: {
+      fontFamily: {
+        // 見出し用: 個性的なDisplay font
+        display: ["Space Grotesk", ...fontFamily.sans],
+        // 本文用: 読みやすいSans
+        sans: ["DM Sans", ...fontFamily.sans],
+        // 数値用: Tabular figures対応のMono
+        mono: ["JetBrains Mono", ...fontFamily.mono],
+      },
+    },
+  },
+};
+```
+
+```tsx
+// コンポーネントでの使用
+<h1 className="font-display text-4xl font-bold tracking-tight">
+  今日のカロリー
+</h1>
+<p className="font-sans text-base text-muted-foreground">
+  目標達成まであと少し
+</p>
+<span className="font-mono text-2xl tabular-nums">
+  1,234 kcal
+</span>
+```
+
+### 2.4 タイポグラフィの階層
+
+明確な視覚的階層を作ること。
+
+```tsx
+// 階層の例
+const typographyScale = {
+  // Display: 最重要の数値・見出し
+  display: "text-5xl md:text-7xl font-display font-bold tracking-tighter",
+
+  // Heading: セクション見出し
+  h1: "text-3xl md:text-4xl font-display font-semibold tracking-tight",
+  h2: "text-2xl md:text-3xl font-display font-semibold",
+  h3: "text-xl md:text-2xl font-display font-medium",
+
+  // Body: 本文
+  body: "text-base font-sans leading-relaxed",
+  small: "text-sm font-sans text-muted-foreground",
+
+  // Data: 数値表示
+  data: "font-mono tabular-nums",
+};
+```
+
+---
+
+## 3. Color & Theme Guidelines
+
+### 3.1 避けるべきカラーパターン
+
+```css
+/* 禁止パターン */
+
+/* 1. 紫グラデーション on 白背景（AI生成感が強い） */
+background: linear-gradient(to right, #8b5cf6, #d946ef);
+
+/* 2. 青から紫のグラデーション（使い古された） */
+background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+
+/* 3. パステル + 白の組み合わせ（無個性） */
+background: #f8fafc;
+color: #94a3b8;
+```
+
+### 3.2 カラーシステムの構築
+
+CSS変数を使用した一貫したテーマを構築する。
+
+```css
+/* globals.css */
+@layer base {
+  :root {
+    /*
+     * CalTrack固有のカラーパレット
+     * コンセプト: "健康的な活力" - 暖かみのあるグリーン基調
+     */
+
+    /* Primary: メインアクション、重要な要素 */
+    --primary: 142 76% 36%;        /* 深みのあるグリーン */
+    --primary-foreground: 0 0% 100%;
+
+    /* Secondary: 補助的な要素 */
+    --secondary: 45 93% 47%;        /* 活力のあるアンバー */
+    --secondary-foreground: 0 0% 0%;
+
+    /* Accent: 注目を引く要素 */
+    --accent: 24 95% 53%;           /* 暖かいオレンジ */
+    --accent-foreground: 0 0% 100%;
+
+    /* Background: 背景色 */
+    --background: 60 9% 98%;        /* オフホワイト（純白を避ける） */
+    --foreground: 20 14% 4%;        /* ほぼ黒（純黒を避ける） */
+
+    /* Muted: 控えめな要素 */
+    --muted: 60 5% 96%;
+    --muted-foreground: 25 5% 45%;
+
+    /* Card: カード背景 */
+    --card: 0 0% 100%;
+    --card-foreground: 20 14% 4%;
+
+    /* Border: 境界線 */
+    --border: 20 6% 90%;
+
+    /* Semantic: 意味のある色 */
+    --success: 142 76% 36%;
+    --warning: 45 93% 47%;
+    --error: 0 84% 60%;
+    --info: 199 89% 48%;
+  }
+
+  .dark {
+    /* ダークテーマ: 純黒を避けた深みのある色 */
+    --background: 20 14% 4%;
+    --foreground: 60 9% 98%;
+    --card: 24 10% 10%;
+    --card-foreground: 60 9% 98%;
+    --muted: 12 6% 15%;
+    --muted-foreground: 24 5% 64%;
+    --border: 12 6% 15%;
+  }
+}
+```
+
+### 3.3 カラーの使い方
+
+```tsx
+// 意図を持ったカラー使用
+const CalorieDisplay = ({ current, goal }: Props) => {
+  const percentage = (current / goal) * 100;
+
+  // 状態に応じた色の変化
+  const getStatusColor = () => {
+    if (percentage < 50) return "text-success";      // まだ余裕
+    if (percentage < 80) return "text-warning";      // 注意
+    if (percentage < 100) return "text-accent";      // もうすぐ
+    return "text-error";                              // 超過
+  };
+
+  return (
+    <div className="relative">
+      {/* グラデーションは控えめに、意図を持って使用 */}
+      <div className="absolute inset-0 bg-gradient-to-b from-primary/5 to-transparent" />
+      <span className={cn("font-mono text-5xl tabular-nums", getStatusColor())}>
+        {current.toLocaleString()}
+      </span>
+    </div>
+  );
+};
+```
+
+---
+
+## 4. Motion & Animation Guidelines
+
+### 4.1 基本原則
+
+- **目的のあるアニメーション**: 装飾ではなく、フィードバックや状態変化を伝える
+- **CSS-firstアプローチ**: 可能な限りCSS transitionを使用
+- **パフォーマンス**: transform と opacity のみアニメーション
+
+### 4.2 CSS Transitionの活用
+
+```css
+/* globals.css */
+@layer base {
+  :root {
+    /* 一貫したタイミング関数 */
+    --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-in-out-expo: cubic-bezier(0.87, 0, 0.13, 1);
+    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+    /* デュレーション */
+    --duration-fast: 150ms;
+    --duration-normal: 250ms;
+    --duration-slow: 400ms;
+  }
+}
+```
+
+```tsx
+// CSS Transitionの実装例
+const Button = ({ children, ...props }: ButtonProps) => (
+  <button
+    className={cn(
+      "relative overflow-hidden",
+      "transition-all duration-[--duration-normal] ease-[--ease-out-expo]",
+      // ホバー時: 軽い浮き上がり
+      "hover:-translate-y-0.5 hover:shadow-lg",
+      // アクティブ時: 押し込み
+      "active:translate-y-0 active:shadow-sm",
+      // フォーカス時: リング表示
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+    )}
+    {...props}
+  >
+    {children}
+  </button>
+);
+```
+
+### 4.3 Framer Motionの活用（必要な場合）
+
+```tsx
+import { motion, AnimatePresence } from "framer-motion";
+
+// リスト項目のスタッガードアニメーション
+const MealList = ({ meals }: { meals: Meal[] }) => (
+  <motion.ul className="space-y-3">
+    <AnimatePresence mode="popLayout">
+      {meals.map((meal, index) => (
+        <motion.li
+          key={meal.id}
+          layout
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, x: -20 }}
+          transition={{
+            duration: 0.25,
+            delay: index * 0.05,
+            ease: [0.16, 1, 0.3, 1],
+          }}
+        >
+          <MealCard meal={meal} />
+        </motion.li>
+      ))}
+    </AnimatePresence>
+  </motion.ul>
+);
+
+// 数値のカウントアップアニメーション
+const AnimatedNumber = ({ value }: { value: number }) => {
+  const springValue = useSpring(value, {
+    stiffness: 100,
+    damping: 30,
+  });
+
+  const display = useTransform(springValue, (v) =>
+    Math.round(v).toLocaleString()
+  );
+
+  return (
+    <motion.span className="font-mono tabular-nums">
+      {display}
+    </motion.span>
+  );
+};
+```
+
+### 4.4 マイクロインタラクション
+
+```tsx
+// 食事記録追加時のフィードバック
+const AddMealButton = () => {
+  const [isAdded, setIsAdded] = useState(false);
+
+  return (
+    <motion.button
+      whileTap={{ scale: 0.95 }}
+      onClick={() => {
+        setIsAdded(true);
+        // 成功フィードバック
+        setTimeout(() => setIsAdded(false), 1500);
+      }}
+      className="relative"
+    >
+      <AnimatePresence mode="wait">
+        {isAdded ? (
+          <motion.span
+            key="success"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            className="flex items-center gap-2 text-success"
+          >
+            <Check className="h-4 w-4" />
+            追加しました
+          </motion.span>
+        ) : (
+          <motion.span
+            key="default"
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.8 }}
+            className="flex items-center gap-2"
+          >
+            <Plus className="h-4 w-4" />
+            食事を追加
+          </motion.span>
+        )}
+      </AnimatePresence>
+    </motion.button>
+  );
+};
+```
+
+---
+
+## 5. Layout & Spatial Composition
+
+### 5.1 予期しないレイアウト
+
+グリッドに縛られない、印象的なレイアウトを作る。
+
+```tsx
+// 非対称レイアウトの例
+const HeroSection = () => (
+  <section className="relative min-h-[80vh] overflow-hidden">
+    {/* 背景: 非対称の装飾 */}
+    <div className="absolute -top-1/4 -right-1/4 h-[600px] w-[600px] rounded-full bg-primary/10 blur-3xl" />
+    <div className="absolute -bottom-1/4 -left-1/4 h-[400px] w-[400px] rounded-full bg-secondary/10 blur-3xl" />
+
+    {/* コンテンツ: オフセットされた配置 */}
+    <div className="container relative grid min-h-[80vh] grid-cols-12 items-center gap-8">
+      {/* 左側: テキスト（5列分、左に寄せる） */}
+      <div className="col-span-12 md:col-span-5 md:col-start-1">
+        <h1 className="font-display text-5xl font-bold tracking-tighter md:text-7xl">
+          食べる。
+          <br />
+          <span className="text-primary">記録する。</span>
+          <br />
+          健康になる。
+        </h1>
+      </div>
+
+      {/* 右側: ビジュアル（6列分、重なりを作る） */}
+      <div className="col-span-12 md:col-span-6 md:col-start-6 md:-mt-20">
+        <CalorieVisualization />
+      </div>
+    </div>
+  </section>
+);
+```
+
+### 5.2 オーバーラップとレイヤー
+
+```tsx
+// カードのオーバーラップ配置
+const StatsOverview = () => (
+  <div className="relative h-[400px]">
+    {/* ベースカード */}
+    <div className="absolute left-0 top-0 w-3/4 rounded-2xl bg-card p-6 shadow-lg">
+      <h3 className="font-display text-lg font-semibold">今週の記録</h3>
+      <WeeklyChart />
+    </div>
+
+    {/* オーバーラップするカード */}
+    <div className="absolute right-0 top-20 w-1/2 rounded-2xl bg-primary p-6 text-primary-foreground shadow-xl">
+      <span className="text-sm opacity-80">本日の達成率</span>
+      <p className="font-mono text-4xl font-bold tabular-nums">87%</p>
+    </div>
+
+    {/* さらに上にオーバーラップ */}
+    <div className="absolute bottom-0 left-1/4 rounded-full bg-secondary px-4 py-2 shadow-lg">
+      <span className="text-sm font-medium">3日連続達成中！</span>
+    </div>
+  </div>
+);
+```
+
+### 5.3 余白の戦略的使用
+
+```tsx
+// 余白で呼吸感を作る
+const SectionLayout = ({ children, title }: LayoutProps) => (
+  <section className="py-20 md:py-32">
+    {/* 見出し: 大きな余白で存在感を出す */}
+    <header className="mb-16 md:mb-24">
+      <h2 className="font-display text-3xl font-bold tracking-tight md:text-5xl">
+        {title}
+      </h2>
+    </header>
+
+    {/* コンテンツ: 適度な余白 */}
+    <div className="space-y-8">
+      {children}
+    </div>
+  </section>
+);
+```
+
+---
+
+## 6. Backgrounds & Visual Details
+
+### 6.1 雰囲気を作る背景
+
+```tsx
+// グレイン（ノイズ）テクスチャ
+const GrainOverlay = () => (
+  <div
+    className="pointer-events-none fixed inset-0 z-50 opacity-[0.015]"
+    style={{
+      backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E")`,
+    }}
+  />
+);
+
+// グラデーションメッシュ背景
+const MeshGradient = () => (
+  <div className="fixed inset-0 -z-10">
+    <div className="absolute inset-0 bg-background" />
+    <div className="absolute left-1/4 top-0 h-[500px] w-[500px] rounded-full bg-primary/20 blur-[100px]" />
+    <div className="absolute right-1/4 top-1/3 h-[400px] w-[400px] rounded-full bg-secondary/20 blur-[100px]" />
+    <div className="absolute bottom-0 left-1/2 h-[600px] w-[600px] -translate-x-1/2 rounded-full bg-accent/10 blur-[120px]" />
+  </div>
+);
+```
+
+### 6.2 装飾的なディテール
+
+```tsx
+// ドット背景パターン
+const DotPattern = () => (
+  <div
+    className="absolute inset-0 -z-10 opacity-[0.4]"
+    style={{
+      backgroundImage: `radial-gradient(circle, hsl(var(--foreground)) 1px, transparent 1px)`,
+      backgroundSize: '24px 24px',
+    }}
+  />
+);
+
+// グリッド背景パターン
+const GridPattern = () => (
+  <div
+    className="absolute inset-0 -z-10"
+    style={{
+      backgroundImage: `
+        linear-gradient(to right, hsl(var(--border)) 1px, transparent 1px),
+        linear-gradient(to bottom, hsl(var(--border)) 1px, transparent 1px)
+      `,
+      backgroundSize: '40px 40px',
+    }}
+  />
+);
+```
+
+### 6.3 カードとコンテナのスタイリング
+
+```tsx
+// 深みのあるカードスタイル
+const Card = ({ children, variant = "default" }: CardProps) => {
+  const variants = {
+    default: cn(
+      "rounded-2xl bg-card p-6",
+      "border border-border/50",
+      "shadow-sm shadow-foreground/5"
+    ),
+    elevated: cn(
+      "rounded-2xl bg-card p-6",
+      "shadow-xl shadow-foreground/10",
+      "ring-1 ring-border/10"
+    ),
+    glass: cn(
+      "rounded-2xl p-6",
+      "bg-card/80 backdrop-blur-xl",
+      "border border-border/30"
+    ),
+  };
+
+  return <div className={variants[variant]}>{children}</div>;
+};
+```
+
+---
+
+## 7. Anti-Patterns（避けるべきパターン）
+
+### 7.1 Typography Anti-Patterns
+
+```tsx
+// 悪い例
+<h1 className="font-sans text-2xl">見出し</h1>  // 階層が不明確
+<p className="text-gray-400">本文</p>            // コントラスト不足
+
+// 良い例
+<h1 className="font-display text-4xl font-bold tracking-tight">見出し</h1>
+<p className="text-muted-foreground">本文</p>
+```
+
+### 7.2 Color Anti-Patterns
+
+```tsx
+// 悪い例: AI生成感の強いグラデーション
+<div className="bg-gradient-to-r from-purple-500 to-pink-500" />
+
+// 悪い例: 意味のない色使い
+<span className="text-blue-500">エラー</span>  // 青はエラーを示さない
+
+// 良い例: 意図を持った色使い
+<span className="text-error">エラーが発生しました</span>
+```
+
+### 7.3 Layout Anti-Patterns
+
+```tsx
+// 悪い例: すべてが中央寄せ
+<div className="flex flex-col items-center justify-center text-center">
+  <h1>見出し</h1>
+  <p>本文</p>
+  <button>ボタン</button>
+</div>
+
+// 良い例: 意図を持った配置
+<div className="flex flex-col items-start">
+  <h1 className="max-w-2xl">見出し</h1>
+  <p className="mt-4 max-w-lg text-muted-foreground">本文</p>
+  <button className="mt-8">ボタン</button>
+</div>
+```
+
+### 7.4 Animation Anti-Patterns
+
+```tsx
+// 悪い例: 過剰なアニメーション
+<motion.div
+  animate={{ rotate: 360, scale: [1, 1.5, 1] }}
+  transition={{ duration: 2, repeat: Infinity }}
+/>
+
+// 悪い例: 目的のないアニメーション
+<div className="animate-bounce" />  // なぜバウンス？
+
+// 良い例: 目的のあるアニメーション
+<motion.div
+  initial={{ opacity: 0, y: 10 }}
+  animate={{ opacity: 1, y: 0 }}
+  transition={{ duration: 0.25 }}
+/>
+```
+
+---
+
+## 8. Checklist
+
+UIを作成する際は以下をチェックすること。
+
+### Design Thinking
+- [ ] Purpose（目的）が明確か
+- [ ] Tone（美的方向性）が決まっているか
+- [ ] Constraints（制約）を把握しているか
+- [ ] Differentiation（差別化要素）があるか
+
+### Typography
+- [ ] 汎用フォントを避けているか
+- [ ] 視覚的階層が明確か
+- [ ] 数値にはtabular-numsを使用しているか
+
+### Color
+- [ ] AI生成感のあるグラデーションを避けているか
+- [ ] CSS変数で一貫したテーマを使用しているか
+- [ ] 純白・純黒を避けているか
+
+### Motion
+- [ ] アニメーションに目的があるか
+- [ ] CSS transitionを優先しているか
+- [ ] パフォーマンスを考慮しているか（transform, opacityのみ）
+
+### Layout
+- [ ] 予測可能すぎるレイアウトを避けているか
+- [ ] 余白を戦略的に使用しているか
+- [ ] オーバーラップやレイヤーを活用しているか
+
+### Visual Details
+- [ ] 背景に深みがあるか
+- [ ] 装飾的なディテールが適切か
+- [ ] カードスタイルに個性があるか

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -1,6 +1,7 @@
 /**
  * RegisterForm - ユーザー登録フォームコンポーネント
  * 新規ユーザー登録のためのフォームUI
+ * Warm & Organicトーンのデザイン
  */
 import * as React from "react";
 import { useState } from "react";
@@ -159,6 +160,66 @@ function getErrorMessage(code: string): string {
 }
 
 /**
+ * AlertCircleアイコン - エラー表示用
+ * SVGインラインアイコン
+ */
+function AlertCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+/**
+ * CheckCircleアイコン - 成功表示用
+ * SVGインラインアイコン
+ */
+function CheckCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}
+
+/**
+ * フィールドエラー表示コンポーネント
+ * アイコン付きのエラーメッセージを表示
+ */
+function FieldError({ id, message }: { id: string; message: string }) {
+  return (
+    <p id={id} className="flex items-center gap-1.5 text-sm text-destructive">
+      <AlertCircleIcon className="w-4 h-4 flex-shrink-0" />
+      <span>{message}</span>
+    </p>
+  );
+}
+
+/**
  * RegisterForm - ユーザー登録フォーム
  */
 export function RegisterForm({ onSuccess }: RegisterFormProps) {
@@ -214,45 +275,55 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
   };
 
   return (
-    <Card className="w-full max-w-md mx-auto">
-      <CardHeader>
-        <CardTitle>新規登録</CardTitle>
-        <CardDescription>
+    <Card className="w-full shadow-warm-lg border-0">
+      <CardHeader className="space-y-1 pb-6">
+        <CardTitle className="text-2xl font-semibold text-center">
+          新規登録
+        </CardTitle>
+        <CardDescription className="text-center text-muted-foreground">
           アカウントを作成して、カロリー管理を始めましょう
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-5">
           {/* APIエラー表示 */}
           {error && (
             <div
-              className="p-3 text-sm text-red-500 bg-red-50 border border-red-200 rounded-md"
+              className="flex items-start gap-3 p-4 text-sm rounded-lg bg-destructive/10 border border-destructive/20"
               role="alert"
             >
-              <p>{getErrorMessage(error.code)}</p>
-              {error.details && error.details.length > 0 && (
-                <ul className="mt-1 list-disc list-inside">
-                  {error.details.map((detail, index) => (
-                    <li key={index}>{detail}</li>
-                  ))}
-                </ul>
-              )}
+              <AlertCircleIcon className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <p className="font-medium text-destructive">
+                  {getErrorMessage(error.code)}
+                </p>
+                {error.details && error.details.length > 0 && (
+                  <ul className="mt-1.5 list-disc list-inside text-destructive/80">
+                    {error.details.map((detail, index) => (
+                      <li key={index}>{detail}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             </div>
           )}
 
           {/* 成功メッセージ */}
           {isSuccess && (
             <div
-              className="p-3 text-sm text-green-500 bg-green-50 border border-green-200 rounded-md"
+              className="flex items-center gap-3 p-4 text-sm rounded-lg bg-success/10 border border-success/20"
               role="status"
             >
-              登録が完了しました
+              <CheckCircleIcon className="w-5 h-5 text-success flex-shrink-0" />
+              <p className="font-medium text-success">登録が完了しました</p>
             </div>
           )}
 
           {/* ニックネーム */}
           <div className="space-y-2">
-            <Label htmlFor="nickname">ニックネーム</Label>
+            <Label htmlFor="nickname" className="text-foreground font-medium">
+              ニックネーム
+            </Label>
             <Input
               id="nickname"
               name="nickname"
@@ -262,18 +333,21 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               placeholder="ニックネームを入力"
               disabled={isLoading}
               aria-invalid={!!formErrors.nickname}
-              aria-describedby={formErrors.nickname ? "nickname-error" : undefined}
+              aria-describedby={
+                formErrors.nickname ? "nickname-error" : undefined
+              }
+              className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
             />
             {formErrors.nickname && (
-              <p id="nickname-error" className="text-sm text-red-500">
-                {formErrors.nickname}
-              </p>
+              <FieldError id="nickname-error" message={formErrors.nickname} />
             )}
           </div>
 
           {/* メールアドレス */}
           <div className="space-y-2">
-            <Label htmlFor="email">メールアドレス</Label>
+            <Label htmlFor="email" className="text-foreground font-medium">
+              メールアドレス
+            </Label>
             <Input
               id="email"
               name="email"
@@ -284,17 +358,18 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               disabled={isLoading}
               aria-invalid={!!formErrors.email}
               aria-describedby={formErrors.email ? "email-error" : undefined}
+              className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
             />
             {formErrors.email && (
-              <p id="email-error" className="text-sm text-red-500">
-                {formErrors.email}
-              </p>
+              <FieldError id="email-error" message={formErrors.email} />
             )}
           </div>
 
           {/* パスワード */}
           <div className="space-y-2">
-            <Label htmlFor="password">パスワード</Label>
+            <Label htmlFor="password" className="text-foreground font-medium">
+              パスワード
+            </Label>
             <Input
               id="password"
               name="password"
@@ -304,64 +379,76 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               placeholder="8文字以上で入力"
               disabled={isLoading}
               aria-invalid={!!formErrors.password}
-              aria-describedby={formErrors.password ? "password-error" : undefined}
+              aria-describedby={
+                formErrors.password ? "password-error" : undefined
+              }
+              className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
             />
             {formErrors.password && (
-              <p id="password-error" className="text-sm text-red-500">
-                {formErrors.password}
-              </p>
+              <FieldError id="password-error" message={formErrors.password} />
             )}
           </div>
 
-          {/* 体重 */}
-          <div className="space-y-2">
-            <Label htmlFor="weight">体重 (kg)</Label>
-            <Input
-              id="weight"
-              name="weight"
-              type="number"
-              step="0.1"
-              min="0"
-              value={formState.weight}
-              onChange={handleChange}
-              placeholder="60"
-              disabled={isLoading}
-              aria-invalid={!!formErrors.weight}
-              aria-describedby={formErrors.weight ? "weight-error" : undefined}
-            />
-            {formErrors.weight && (
-              <p id="weight-error" className="text-sm text-red-500">
-                {formErrors.weight}
-              </p>
-            )}
-          </div>
+          {/* 体重・身長（2カラム） */}
+          <div className="grid grid-cols-2 gap-4">
+            {/* 体重 */}
+            <div className="space-y-2">
+              <Label htmlFor="weight" className="text-foreground font-medium">
+                体重 (kg)
+              </Label>
+              <Input
+                id="weight"
+                name="weight"
+                type="number"
+                step="0.1"
+                min="0"
+                value={formState.weight}
+                onChange={handleChange}
+                placeholder="60"
+                disabled={isLoading}
+                aria-invalid={!!formErrors.weight}
+                aria-describedby={
+                  formErrors.weight ? "weight-error" : undefined
+                }
+                className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
+              />
+              {formErrors.weight && (
+                <FieldError id="weight-error" message={formErrors.weight} />
+              )}
+            </div>
 
-          {/* 身長 */}
-          <div className="space-y-2">
-            <Label htmlFor="height">身長 (cm)</Label>
-            <Input
-              id="height"
-              name="height"
-              type="number"
-              step="0.1"
-              min="0"
-              value={formState.height}
-              onChange={handleChange}
-              placeholder="170"
-              disabled={isLoading}
-              aria-invalid={!!formErrors.height}
-              aria-describedby={formErrors.height ? "height-error" : undefined}
-            />
-            {formErrors.height && (
-              <p id="height-error" className="text-sm text-red-500">
-                {formErrors.height}
-              </p>
-            )}
+            {/* 身長 */}
+            <div className="space-y-2">
+              <Label htmlFor="height" className="text-foreground font-medium">
+                身長 (cm)
+              </Label>
+              <Input
+                id="height"
+                name="height"
+                type="number"
+                step="0.1"
+                min="0"
+                value={formState.height}
+                onChange={handleChange}
+                placeholder="170"
+                disabled={isLoading}
+                aria-invalid={!!formErrors.height}
+                aria-describedby={
+                  formErrors.height ? "height-error" : undefined
+                }
+                className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
+              />
+              {formErrors.height && (
+                <FieldError id="height-error" message={formErrors.height} />
+              )}
+            </div>
           </div>
 
           {/* 生年月日 */}
           <div className="space-y-2">
-            <Label htmlFor="birthDate">生年月日</Label>
+            <Label htmlFor="birthDate" className="text-foreground font-medium">
+              生年月日
+            </Label>
             <Input
               id="birthDate"
               name="birthDate"
@@ -370,18 +457,21 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               onChange={handleChange}
               disabled={isLoading}
               aria-invalid={!!formErrors.birthDate}
-              aria-describedby={formErrors.birthDate ? "birthDate-error" : undefined}
+              aria-describedby={
+                formErrors.birthDate ? "birthDate-error" : undefined
+              }
+              className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
             />
             {formErrors.birthDate && (
-              <p id="birthDate-error" className="text-sm text-red-500">
-                {formErrors.birthDate}
-              </p>
+              <FieldError id="birthDate-error" message={formErrors.birthDate} />
             )}
           </div>
 
           {/* 性別 */}
           <div className="space-y-2">
-            <Label htmlFor="gender">性別</Label>
+            <Label htmlFor="gender" className="text-foreground font-medium">
+              性別
+            </Label>
             <Select
               id="gender"
               name="gender"
@@ -390,6 +480,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               disabled={isLoading}
               aria-invalid={!!formErrors.gender}
               aria-describedby={formErrors.gender ? "gender-error" : undefined}
+              className="h-11"
             >
               <SelectOption value="">選択してください</SelectOption>
               {GENDER_OPTIONS.map((option) => (
@@ -399,15 +490,18 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               ))}
             </Select>
             {formErrors.gender && (
-              <p id="gender-error" className="text-sm text-red-500">
-                {formErrors.gender}
-              </p>
+              <FieldError id="gender-error" message={formErrors.gender} />
             )}
           </div>
 
           {/* 活動レベル */}
           <div className="space-y-2">
-            <Label htmlFor="activityLevel">活動レベル</Label>
+            <Label
+              htmlFor="activityLevel"
+              className="text-foreground font-medium"
+            >
+              活動レベル
+            </Label>
             <Select
               id="activityLevel"
               name="activityLevel"
@@ -418,6 +512,7 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               aria-describedby={
                 formErrors.activityLevel ? "activityLevel-error" : undefined
               }
+              className="h-11"
             >
               <SelectOption value="">選択してください</SelectOption>
               {ACTIVITY_LEVEL_OPTIONS.map((option) => (
@@ -427,14 +522,19 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
               ))}
             </Select>
             {formErrors.activityLevel && (
-              <p id="activityLevel-error" className="text-sm text-red-500">
-                {formErrors.activityLevel}
-              </p>
+              <FieldError
+                id="activityLevel-error"
+                message={formErrors.activityLevel}
+              />
             )}
           </div>
 
           {/* 送信ボタン */}
-          <Button type="submit" className="w-full" disabled={isLoading}>
+          <Button
+            type="submit"
+            className="w-full h-12 text-base font-medium mt-6 bg-primary hover:bg-primary/90 transition-colors"
+            disabled={isLoading}
+          >
             {isLoading ? "登録中..." : "登録する"}
           </Button>
         </form>

--- a/frontend/src/features/auth/components/RegisterPage.tsx
+++ b/frontend/src/features/auth/components/RegisterPage.tsx
@@ -1,6 +1,7 @@
 /**
  * RegisterPage - 新規登録ページコンポーネント
  * ルーティング対応のためのページラッパー
+ * Warm & Organicトーンのデザイン
  */
 import { useNavigate } from "react-router-dom";
 import { RegisterForm } from "./RegisterForm";
@@ -13,7 +14,7 @@ export type RegisterPageProps = {
 
 /**
  * RegisterPage - 新規登録ページ
- * フルページレイアウトでRegisterFormを表示
+ * 背景装飾とロゴエリアを含むフルページレイアウト
  */
 export function RegisterPage({ redirectTo = "/" }: RegisterPageProps) {
   const navigate = useNavigate();
@@ -27,8 +28,42 @@ export function RegisterPage({ redirectTo = "/" }: RegisterPageProps) {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
-      <RegisterForm onSuccess={handleSuccess} />
+    <div className="min-h-screen w-full flex flex-col items-center justify-center bg-background py-12 px-4 sm:px-6 lg:px-8 relative overflow-hidden">
+      {/* 背景装飾 - 有機的な円形グラデーション */}
+      <div
+        className="absolute top-0 right-0 w-96 h-96 rounded-full opacity-30 blur-3xl -translate-y-1/2 translate-x-1/2"
+        style={{
+          background:
+            "radial-gradient(circle, hsl(142 40% 45% / 0.4) 0%, transparent 70%)",
+        }}
+        aria-hidden="true"
+      />
+      <div
+        className="absolute bottom-0 left-0 w-80 h-80 rounded-full opacity-20 blur-3xl translate-y-1/2 -translate-x-1/2"
+        style={{
+          background:
+            "radial-gradient(circle, hsl(25 80% 55% / 0.3) 0%, transparent 70%)",
+        }}
+        aria-hidden="true"
+      />
+
+      {/* コンテンツ幅制限用コンテナ - PC表示時の幅を制限 */}
+      <div className="w-full max-w-screen-sm mx-auto flex flex-col items-center relative z-10">
+        {/* ロゴエリア */}
+        <div className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-primary tracking-tight">
+            CalTrack
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            あなたの健康的な食生活をサポート
+          </p>
+        </div>
+
+        {/* 登録フォーム */}
+        <div className="w-full max-w-md">
+          <RegisterForm onSuccess={handleSuccess} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -4,48 +4,95 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* Warm & Organic カラーパレット */
+
+    /* 背景 - クリーミーホワイト（オフホワイト） */
+    --background: 40 30% 97%;
+    /* 前景 - 温かみのあるダークブラウン */
+    --foreground: 25 20% 20%;
+
+    /* カード - 純白（背景との対比） */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 25 20% 20%;
+
+    /* ポップオーバー */
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
-    --radius: 0.5rem;
+    --popover-foreground: 25 20% 20%;
+
+    /* プライマリ - 健康的なセージグリーン */
+    --primary: 142 40% 45%;
+    --primary-foreground: 0 0% 100%;
+
+    /* セカンダリ - 暖かいベージュ */
+    --secondary: 30 30% 90%;
+    --secondary-foreground: 25 25% 25%;
+
+    /* ミュート - 薄いベージュ */
+    --muted: 40 20% 93%;
+    --muted-foreground: 25 10% 50%;
+
+    /* アクセント - 暖かいオレンジ */
+    --accent: 25 80% 55%;
+    --accent-foreground: 0 0% 100%;
+
+    /* エラー - コーラルレッド（柔らかい赤） */
+    --destructive: 0 65% 55%;
+    --destructive-foreground: 0 0% 100%;
+
+    /* 成功 - 健康的な緑 */
+    --success: 142 50% 45%;
+    --success-foreground: 0 0% 100%;
+
+    /* 警告 - 暖かいオレンジイエロー */
+    --warning: 38 90% 55%;
+    --warning-foreground: 25 20% 20%;
+
+    /* ボーダー・インプット */
+    --border: 40 20% 88%;
+    --input: 40 20% 88%;
+
+    /* フォーカスリング */
+    --ring: 142 40% 45%;
+
+    /* 角丸 - より丸みを帯びた印象 */
+    --radius: 0.75rem;
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    /* ダークモード - 温かみのあるダーク */
+    --background: 25 20% 10%;
+    --foreground: 40 20% 95%;
+
+    --card: 25 15% 15%;
+    --card-foreground: 40 20% 95%;
+
+    --popover: 25 15% 15%;
+    --popover-foreground: 40 20% 95%;
+
+    --primary: 142 40% 50%;
+    --primary-foreground: 25 20% 10%;
+
+    --secondary: 25 15% 20%;
+    --secondary-foreground: 40 20% 95%;
+
+    --muted: 25 15% 20%;
+    --muted-foreground: 40 10% 60%;
+
+    --accent: 25 80% 50%;
+    --accent-foreground: 0 0% 100%;
+
+    --destructive: 0 55% 45%;
+    --destructive-foreground: 0 0% 100%;
+
+    --success: 142 45% 40%;
+    --success-foreground: 0 0% 100%;
+
+    --warning: 38 80% 50%;
+    --warning-foreground: 25 20% 10%;
+
+    --border: 25 15% 25%;
+    --input: 25 15% 25%;
+    --ring: 142 40% 50%;
   }
 }
 
@@ -55,5 +102,22 @@
   }
   body {
     @apply bg-background text-foreground;
+    /* 滑らかなフォントレンダリング */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+/* カスタムユーティリティ */
+@layer utilities {
+  /* 温かみのあるシャドウ */
+  .shadow-warm {
+    box-shadow: 0 4px 20px -2px rgba(139, 115, 85, 0.15),
+                0 2px 8px -2px rgba(139, 115, 85, 0.1);
+  }
+
+  .shadow-warm-lg {
+    box-shadow: 0 10px 40px -4px rgba(139, 115, 85, 0.2),
+                0 4px 16px -4px rgba(139, 115, 85, 0.15);
   }
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -48,6 +48,14 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        success: {
+          DEFAULT: "hsl(var(--success))",
+          foreground: "hsl(var(--success-foreground))",
+        },
+        warning: {
+          DEFAULT: "hsl(var(--warning))",
+          foreground: "hsl(var(--warning-foreground))",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary
- frontend-designスキル（UIデザインガイドライン）を新規作成
- Warm & Organicトーンのカラーパレットに変更（セージグリーン + ベージュ系）
- RegisterPageに背景装飾、ロゴエリア、PC幅制限を追加
- RegisterFormのスタイル変更と2カラムレイアウト対応

## Test plan
- [x] Build: Pass
- [x] Test: Pass (39 tests)

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)