### PR TITLE
refactor: テストケース名を日本語に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,7 @@ docker compose up --build
 
 ### 共通
 - **コメントは日本語で記述**
+- **テストケース名は日本語で記述**
 - マジックナンバー禁止（定数化）
 - エラーコード・メッセージは定数化
 - Usecase, Handler はドメイン単位で1ファイル
@@ -206,6 +207,7 @@ docker compose up --build
 - `go fmt` でフォーマット
 - テストファイル: `{file}_test.go`
 - テストパッケージ: `{package}_test`
+- **テストケース名は日本語**: `t.Run` の第1引数、テーブル駆動テストのnameは日本語
 
 ### Frontend (TypeScript/React)
 - ESLint / Prettier でフォーマット
@@ -213,6 +215,7 @@ docker compose up --build
 - **`interface` ではなく `type` を使用**
 - テストファイル: `{file}.test.ts(x)`
 - 定数: `ERROR_CODE_XXX`, `ERROR_MESSAGE_XXX`
+- **テストケース名は日本語**: `describe`, `it` の第1引数は日本語
 - **必須スキル参照**: `.claude/skills/` 配下のスキルを必ず読む
   - `vercel-react-best-practices` - パフォーマンス最適化
   - `vercel-composition-patterns` - コンポーネント構成

--- a/backend/domain/entity/session_test.go
+++ b/backend/domain/entity/session_test.go
@@ -37,8 +37,8 @@ func TestNewSession_InvalidUserID(t *testing.T) {
 		userID  string
 		wantErr error
 	}{
-		{"empty user id", "", domainErrors.ErrInvalidUserID},
-		{"invalid uuid format", "invalid-uuid", domainErrors.ErrInvalidUserID},
+		{"空のユーザーIDはエラー", "", domainErrors.ErrInvalidUserID},
+		{"無効なUUID形式はエラー", "invalid-uuid", domainErrors.ErrInvalidUserID},
 	}
 
 	for _, tt := range tests {
@@ -140,9 +140,9 @@ func TestReconstructSession_InvalidSessionID(t *testing.T) {
 		name      string
 		sessionID string
 	}{
-		{"empty session id", ""},
-		{"invalid base64", "not-valid-base64!!!"},
-		{"too short base64", "YWJjZA=="},
+		{"空のセッションIDはエラー", ""},
+		{"無効なbase64はエラー", "not-valid-base64!!!"},
+		{"短すぎるbase64はエラー", "YWJjZA=="},
 	}
 
 	for _, tt := range tests {
@@ -171,8 +171,8 @@ func TestReconstructSession_InvalidUserID(t *testing.T) {
 		name   string
 		userID string
 	}{
-		{"empty user id", ""},
-		{"invalid uuid format", "invalid-uuid"},
+		{"空のユーザーIDはエラー", ""},
+		{"無効なUUID形式はエラー", "invalid-uuid"},
 	}
 
 	for _, tt := range tests {
@@ -203,9 +203,9 @@ func TestSession_IsExpired(t *testing.T) {
 		want      bool
 	}{
 		// 有効期限内（未来）
-		{"not expired", time.Now().Add(24 * time.Hour), false},
+		{"期限内は期限切れでない", time.Now().Add(24 * time.Hour), false},
 		// 有効期限切れ（過去）
-		{"expired", time.Now().Add(-24 * time.Hour), true},
+		{"期限切れは期限切れ", time.Now().Add(-24 * time.Hour), true},
 	}
 
 	for _, tt := range tests {
@@ -236,9 +236,9 @@ func TestSession_ValidateNotExpired(t *testing.T) {
 		wantErr   error
 	}{
 		// 有効期限内（未来）
-		{"valid", time.Now().Add(24 * time.Hour), nil},
+		{"有効期限内はエラーなし", time.Now().Add(24 * time.Hour), nil},
 		// 有効期限切れ（過去）
-		{"expired", time.Now().Add(-24 * time.Hour), domainErrors.ErrSessionExpired},
+		{"有効期限切れはエラー", time.Now().Add(-24 * time.Hour), domainErrors.ErrSessionExpired},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/entity/user_test.go
+++ b/backend/domain/entity/user_test.go
@@ -56,8 +56,8 @@ func TestNewUser_ValidationErrors(t *testing.T) {
 		email   string
 		wantErr error
 	}{
-		{"invalid email", "invalid", domainErrors.ErrInvalidEmailFormat},
-		{"empty email", "", domainErrors.ErrEmailRequired},
+		{"無効なメールアドレス形式", "invalid", domainErrors.ErrInvalidEmailFormat},
+		{"空のメールアドレス", "", domainErrors.ErrEmailRequired},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/activity_level_test.go
+++ b/backend/domain/vo/activity_level_test.go
@@ -15,15 +15,15 @@ func TestNewActivityLevel(t *testing.T) {
 		wantErr   error
 	}{
 		// 正常系
-		{"sedentary", "sedentary", "sedentary", nil},
-		{"light", "light", "light", nil},
-		{"moderate", "moderate", "moderate", nil},
-		{"active", "active", "active", nil},
-		{"veryActive", "veryActive", "veryActive", nil},
+		{"sedentaryは有効", "sedentary", "sedentary", nil},
+		{"lightは有効", "light", "light", nil},
+		{"moderateは有効", "moderate", "moderate", nil},
+		{"activeは有効", "active", "active", nil},
+		{"veryActiveは有効", "veryActive", "veryActive", nil},
 		// 異常系
-		{"empty", "", "", domainErrors.ErrInvalidActivityLevel},
-		{"invalid", "unknown", "", domainErrors.ErrInvalidActivityLevel},
-		{"wrong case", "Sedentary", "", domainErrors.ErrInvalidActivityLevel},
+		{"空文字はエラー", "", "", domainErrors.ErrInvalidActivityLevel},
+		{"無効な値はエラー", "unknown", "", domainErrors.ErrInvalidActivityLevel},
+		{"大文字始まりはエラー", "Sedentary", "", domainErrors.ErrInvalidActivityLevel},
 	}
 
 	for _, tt := range tests {
@@ -47,11 +47,11 @@ func TestActivityLevel_Multiplier(t *testing.T) {
 		level          string
 		wantMultiplier float64
 	}{
-		{"sedentary", "sedentary", 1.2},
-		{"light", "light", 1.375},
-		{"moderate", "moderate", 1.55},
-		{"active", "active", 1.725},
-		{"veryActive", "veryActive", 1.9},
+		{"sedentaryの係数は1.2", "sedentary", 1.2},
+		{"lightの係数は1.375", "light", 1.375},
+		{"moderateの係数は1.55", "moderate", 1.55},
+		{"activeの係数は1.725", "active", 1.725},
+		{"veryActiveの係数は1.9", "veryActive", 1.9},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/birthdate_test.go
+++ b/backend/domain/vo/birthdate_test.go
@@ -25,15 +25,15 @@ func TestNewBirthDate(t *testing.T) {
 		wantErr error
 	}{
 		// 正常系
-		{"valid birthdate 1990-01-01", time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC), nil},
-		{"valid birthdate 2000-12-31", time.Date(2000, 12, 31, 0, 0, 0, 0, time.UTC), nil},
+		{"正常な生年月日1990-01-01", time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC), nil},
+		{"正常な生年月日2000-12-31", time.Date(2000, 12, 31, 0, 0, 0, 0, time.UTC), nil},
 		// 異常系
-		{"future date", tomorrow, domainErrors.ErrBirthDateMustBePast},
-		{"today", today, domainErrors.ErrBirthDateMustBePast},
-		{"too old 151 years ago", yearsAgo151, domainErrors.ErrBirthDateTooOld},
+		{"未来の日付はエラー", tomorrow, domainErrors.ErrBirthDateMustBePast},
+		{"今日の日付はエラー", today, domainErrors.ErrBirthDateMustBePast},
+		{"151年前はエラー", yearsAgo151, domainErrors.ErrBirthDateTooOld},
 		// 境界値
-		{"yesterday", yesterday, nil},
-		{"exactly 150 years ago", yearsAgo150, nil},
+		{"昨日は有効", yesterday, nil},
+		{"ちょうど150年前は有効", yearsAgo150, nil},
 	}
 
 	for _, tt := range tests {
@@ -58,10 +58,10 @@ func TestBirthDate_Age(t *testing.T) {
 		birthDate time.Time
 		wantAge   int
 	}{
-		{"born 1990-01-01, age 34", time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC), 34},
-		{"born 2000-06-15, age 24 (birthday today)", time.Date(2000, 6, 15, 0, 0, 0, 0, time.UTC), 24},
-		{"born 2000-06-16, age 23 (birthday tomorrow)", time.Date(2000, 6, 16, 0, 0, 0, 0, time.UTC), 23},
-		{"born 2000-06-14, age 24 (birthday yesterday)", time.Date(2000, 6, 14, 0, 0, 0, 0, time.UTC), 24},
+		{"1990-01-01生まれは34歳", time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC), 34},
+		{"2000-06-15生まれは24歳（誕生日当日）", time.Date(2000, 6, 15, 0, 0, 0, 0, time.UTC), 24},
+		{"2000-06-16生まれは23歳（誕生日前日）", time.Date(2000, 6, 16, 0, 0, 0, 0, time.UTC), 23},
+		{"2000-06-14生まれは24歳（誕生日翌日）", time.Date(2000, 6, 14, 0, 0, 0, 0, time.UTC), 24},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/email_test.go
+++ b/backend/domain/vo/email_test.go
@@ -23,17 +23,17 @@ func TestNewEmail(t *testing.T) {
 		wantErr   error
 	}{
 		// 正常系
-		{"valid email", "user@example.com", "user@example.com", nil},
-		{"valid email with subdomain", "user@mail.example.com", "user@mail.example.com", nil},
-		{"valid email with plus", "user+tag@example.com", "user+tag@example.com", nil},
+		{"正常なメールアドレス", "user@example.com", "user@example.com", nil},
+		{"サブドメイン付きメールアドレス", "user@mail.example.com", "user@mail.example.com", nil},
+		{"プラス記号付きメールアドレス", "user+tag@example.com", "user+tag@example.com", nil},
 		// 異常系
-		{"empty string", "", "", domainErrors.ErrEmailRequired},
-		{"no at sign", "userexample.com", "", domainErrors.ErrInvalidEmailFormat},
-		{"no domain", "user@", "", domainErrors.ErrInvalidEmailFormat},
-		{"no local part", "@example.com", "", domainErrors.ErrInvalidEmailFormat},
+		{"空文字の場合はエラー", "", "", domainErrors.ErrEmailRequired},
+		{"@がない場合はエラー", "userexample.com", "", domainErrors.ErrInvalidEmailFormat},
+		{"ドメインがない場合はエラー", "user@", "", domainErrors.ErrInvalidEmailFormat},
+		{"ローカルパートがない場合はエラー", "@example.com", "", domainErrors.ErrInvalidEmailFormat},
 		// 境界値
-		{"max length 254", email254, email254, nil},
-		{"exceeds 254", email255, "", domainErrors.ErrEmailTooLong},
+		{"最大長254文字は有効", email254, email254, nil},
+		{"255文字以上はエラー", email255, "", domainErrors.ErrEmailTooLong},
 	}
 
 	for _, tt := range tests {
@@ -58,8 +58,8 @@ func TestEmail_Equals(t *testing.T) {
 		email2 string
 		want   bool
 	}{
-		{"same value", "user@example.com", "user@example.com", true},
-		{"different value", "user1@example.com", "user2@example.com", false},
+		{"同じ値の場合はtrue", "user@example.com", "user@example.com", true},
+		{"異なる値の場合はfalse", "user1@example.com", "user2@example.com", false},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/expires_at_test.go
+++ b/backend/domain/vo/expires_at_test.go
@@ -43,11 +43,11 @@ func TestExpiresAt_IsExpired(t *testing.T) {
 		want      bool
 	}{
 		// 有効期限内
-		{"future", fixedNow.Add(1 * time.Hour), false},
-		{"exactly now", fixedNow, false},
+		{"未来の時刻は期限切れでない", fixedNow.Add(1 * time.Hour), false},
+		{"現在時刻は期限切れでない", fixedNow, false},
 		// 有効期限切れ
-		{"past by 1 second", fixedNow.Add(-1 * time.Second), true},
-		{"past by 1 day", fixedNow.AddDate(0, 0, -1), true},
+		{"1秒前は期限切れ", fixedNow.Add(-1 * time.Second), true},
+		{"1日前は期限切れ", fixedNow.AddDate(0, 0, -1), true},
 	}
 
 	for _, tt := range tests {
@@ -72,9 +72,9 @@ func TestExpiresAt_ValidateNotExpired(t *testing.T) {
 		wantErr   error
 	}{
 		// 有効期限内
-		{"valid", fixedNow.Add(1 * time.Hour), nil},
+		{"有効期限内はエラーなし", fixedNow.Add(1 * time.Hour), nil},
 		// 有効期限切れ
-		{"expired", fixedNow.Add(-1 * time.Second), domainErrors.ErrSessionExpired},
+		{"有効期限切れはエラー", fixedNow.Add(-1 * time.Second), domainErrors.ErrSessionExpired},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/gender_test.go
+++ b/backend/domain/vo/gender_test.go
@@ -15,13 +15,13 @@ func TestNewGender(t *testing.T) {
 		wantErr    error
 	}{
 		// 正常系
-		{"male", "male", "male", nil},
-		{"female", "female", "female", nil},
-		{"other", "other", "other", nil},
+		{"maleは有効", "male", "male", nil},
+		{"femaleは有効", "female", "female", nil},
+		{"otherは有効", "other", "other", nil},
 		// 異常系
-		{"empty", "", "", domainErrors.ErrInvalidGender},
-		{"invalid", "unknown", "", domainErrors.ErrInvalidGender},
-		{"uppercase MALE", "MALE", "", domainErrors.ErrInvalidGender},
+		{"空文字はエラー", "", "", domainErrors.ErrInvalidGender},
+		{"無効な値はエラー", "unknown", "", domainErrors.ErrInvalidGender},
+		{"大文字MALEはエラー", "MALE", "", domainErrors.ErrInvalidGender},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/height_test.go
+++ b/backend/domain/vo/height_test.go
@@ -15,16 +15,16 @@ func TestNewHeight(t *testing.T) {
 		wantErr error
 	}{
 		// 正常系
-		{"valid height 170.5cm", 170.5, 170.5, nil},
-		{"valid height 100cm", 100, 100, nil},
+		{"正常な身長170.5cm", 170.5, 170.5, nil},
+		{"正常な身長100cm", 100, 100, nil},
 		// 異常系
-		{"zero", 0, 0, domainErrors.ErrHeightMustBePositive},
-		{"negative", -10, 0, domainErrors.ErrHeightMustBePositive},
-		{"too tall 301cm", 301, 0, domainErrors.ErrHeightTooTall},
+		{"0はエラー", 0, 0, domainErrors.ErrHeightMustBePositive},
+		{"負の値はエラー", -10, 0, domainErrors.ErrHeightMustBePositive},
+		{"301cm以上はエラー", 301, 0, domainErrors.ErrHeightTooTall},
 		// 境界値
-		{"min positive 0.1cm", 0.1, 0.1, nil},
-		{"max height 300cm", 300, 300, nil},
-		{"exceeds max 300.1cm", 300.1, 0, domainErrors.ErrHeightTooTall},
+		{"最小値0.1cmは有効", 0.1, 0.1, nil},
+		{"最大値300cmは有効", 300, 300, nil},
+		{"300.1cmは無効", 300.1, 0, domainErrors.ErrHeightTooTall},
 	}
 
 	for _, tt := range tests {
@@ -48,9 +48,9 @@ func TestHeight_Meters(t *testing.T) {
 		inputCm    float64
 		wantMeters float64
 	}{
-		{"170cm to 1.7m", 170, 1.7},
-		{"100cm to 1m", 100, 1.0},
-		{"185.5cm to 1.855m", 185.5, 1.855},
+		{"170cmは1.7mに変換", 170, 1.7},
+		{"100cmは1mに変換", 100, 1.0},
+		{"185.5cmは1.855mに変換", 185.5, 1.855},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/nickname_test.go
+++ b/backend/domain/vo/nickname_test.go
@@ -16,15 +16,15 @@ func TestNewNickname(t *testing.T) {
 		wantErr      error
 	}{
 		// 正常系
-		{"valid nickname", "John", "John", nil},
-		{"valid with spaces", "John Doe", "John Doe", nil},
+		{"正常なニックネーム", "John", "John", nil},
+		{"スペース付きニックネーム", "John Doe", "John Doe", nil},
 		// 異常系
-		{"empty string", "", "", domainErrors.ErrNicknameRequired},
-		{"too long 51 chars", strings.Repeat("a", 51), "", domainErrors.ErrNicknameTooLong},
+		{"空文字の場合はエラー", "", "", domainErrors.ErrNicknameRequired},
+		{"51文字以上はエラー", strings.Repeat("a", 51), "", domainErrors.ErrNicknameTooLong},
 		// 境界値
-		{"min length 1 char", "A", "A", nil},
-		{"max length 50 chars", strings.Repeat("a", 50), strings.Repeat("a", 50), nil},
-		{"exceeds 50 chars", strings.Repeat("a", 51), "", domainErrors.ErrNicknameTooLong},
+		{"最小長1文字は有効", "A", "A", nil},
+		{"最大長50文字は有効", strings.Repeat("a", 50), strings.Repeat("a", 50), nil},
+		{"51文字は無効", strings.Repeat("a", 51), "", domainErrors.ErrNicknameTooLong},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/password_test.go
+++ b/backend/domain/vo/password_test.go
@@ -14,14 +14,14 @@ func TestNewPassword(t *testing.T) {
 		wantErr error
 	}{
 		// 正常系
-		{"valid 8 chars", "12345678", nil},
-		{"valid long password", "verylongpassword123", nil},
+		{"8文字のパスワードは有効", "12345678", nil},
+		{"長いパスワードは有効", "verylongpassword123", nil},
 		// 異常系
-		{"empty string", "", domainErrors.ErrPasswordRequired},
-		{"too short 7 chars", "1234567", domainErrors.ErrPasswordTooShort},
+		{"空文字はエラー", "", domainErrors.ErrPasswordRequired},
+		{"7文字はエラー", "1234567", domainErrors.ErrPasswordTooShort},
 		// 境界値
-		{"exactly 8 chars", "abcdefgh", nil},
-		{"only 7 chars", "abcdefg", domainErrors.ErrPasswordTooShort},
+		{"ちょうど8文字は有効", "abcdefgh", nil},
+		{"7文字は無効", "abcdefg", domainErrors.ErrPasswordTooShort},
 	}
 
 	for _, tt := range tests {
@@ -60,8 +60,8 @@ func TestHashedPassword_Compare(t *testing.T) {
 		input     string
 		wantMatch bool
 	}{
-		{"correct password", "12345678", true},
-		{"wrong password", "wrongpassword", false},
+		{"正しいパスワードは一致", "12345678", true},
+		{"間違ったパスワードは不一致", "wrongpassword", false},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/session_id_test.go
+++ b/backend/domain/vo/session_id_test.go
@@ -43,11 +43,11 @@ func TestParseSessionID(t *testing.T) {
 		wantErr error
 	}{
 		// 正常系
-		{"valid session id", validID.String(), nil},
+		{"有効なセッションID", validID.String(), nil},
 		// 異常系
-		{"empty string", "", domainErrors.ErrInvalidSessionID},
-		{"invalid base64", "not-valid-base64!!!", domainErrors.ErrInvalidSessionID},
-		{"too short", "YWJjZA==", domainErrors.ErrInvalidSessionID}, // "abcd" in base64
+		{"空文字はエラー", "", domainErrors.ErrInvalidSessionID},
+		{"無効なbase64はエラー", "not-valid-base64!!!", domainErrors.ErrInvalidSessionID},
+		{"短すぎるとエラー", "YWJjZA==", domainErrors.ErrInvalidSessionID}, // "abcd" in base64
 	}
 
 	for _, tt := range tests {
@@ -76,8 +76,8 @@ func TestSessionID_Equals(t *testing.T) {
 		id2  vo.SessionID
 		want bool
 	}{
-		{"same value", id1, id2, true},
-		{"different value", id1, id3, false},
+		{"同じ値はtrue", id1, id2, true},
+		{"異なる値はfalse", id1, id3, false},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/user_id_test.go
+++ b/backend/domain/vo/user_id_test.go
@@ -29,11 +29,11 @@ func TestParseUserID(t *testing.T) {
 		wantErr error
 	}{
 		// 正常系
-		{"valid UUID", validUUID, validUUID, nil},
+		{"有効なUUID", validUUID, validUUID, nil},
 		// 異常系
-		{"empty string", "", "", domainErrors.ErrInvalidUserID},
-		{"invalid format", "invalid", "", domainErrors.ErrInvalidUserID},
-		{"partial UUID", "550e8400-e29b", "", domainErrors.ErrInvalidUserID},
+		{"空文字はエラー", "", "", domainErrors.ErrInvalidUserID},
+		{"無効な形式はエラー", "invalid", "", domainErrors.ErrInvalidUserID},
+		{"不完全なUUIDはエラー", "550e8400-e29b", "", domainErrors.ErrInvalidUserID},
 	}
 
 	for _, tt := range tests {
@@ -63,8 +63,8 @@ func TestUserID_Equals(t *testing.T) {
 		id2  vo.UserID
 		want bool
 	}{
-		{"same value", id1, id2, true},
-		{"different value", id1, id3, false},
+		{"同じ値はtrue", id1, id2, true},
+		{"異なる値はfalse", id1, id3, false},
 	}
 
 	for _, tt := range tests {

--- a/backend/domain/vo/weight_test.go
+++ b/backend/domain/vo/weight_test.go
@@ -15,16 +15,16 @@ func TestNewWeight(t *testing.T) {
 		wantErr error
 	}{
 		// 正常系
-		{"valid weight 70.5kg", 70.5, 70.5, nil},
-		{"valid weight 1kg", 1.0, 1.0, nil},
+		{"正常な体重70.5kg", 70.5, 70.5, nil},
+		{"正常な体重1kg", 1.0, 1.0, nil},
 		// 異常系
-		{"zero", 0, 0, domainErrors.ErrWeightMustBePositive},
-		{"negative", -10, 0, domainErrors.ErrWeightMustBePositive},
-		{"too heavy 501kg", 501, 0, domainErrors.ErrWeightTooHeavy},
+		{"0はエラー", 0, 0, domainErrors.ErrWeightMustBePositive},
+		{"負の値はエラー", -10, 0, domainErrors.ErrWeightMustBePositive},
+		{"501kg以上はエラー", 501, 0, domainErrors.ErrWeightTooHeavy},
 		// 境界値
-		{"min positive 0.1kg", 0.1, 0.1, nil},
-		{"max weight 500kg", 500, 500, nil},
-		{"exceeds max 500.1kg", 500.1, 0, domainErrors.ErrWeightTooHeavy},
+		{"最小値0.1kgは有効", 0.1, 0.1, nil},
+		{"最大値500kgは有効", 500, 500, nil},
+		{"500.1kgは無効", 500.1, 0, domainErrors.ErrWeightTooHeavy},
 	}
 
 	for _, tt := range tests {

--- a/frontend/src/features/auth/components/RegisterForm.test.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.test.tsx
@@ -161,7 +161,7 @@ describe("RegisterForm", () => {
   });
 
   describe("フォーム送信", () => {
-    it("有効なデータでフォームを送信するとregister関数が呼ばれる", async () => {
+    it("有効なデータでフォームを送信すると登録関数が呼ばれる", async () => {
       const user = userEvent.setup();
       render(<RegisterForm />);
 
@@ -195,7 +195,7 @@ describe("RegisterForm", () => {
       });
     });
 
-    it("onSuccessコールバックがregister関数に渡される", async () => {
+    it("onSuccessコールバックが登録関数に渡される", async () => {
       const onSuccess = vi.fn();
       const user = userEvent.setup();
       render(<RegisterForm onSuccess={onSuccess} />);
@@ -223,7 +223,7 @@ describe("RegisterForm", () => {
   });
 
   describe("ローディング状態", () => {
-    it("isLoadingがtrueの時、ボタンが無効化される", () => {
+    it("ローディング中はボタンが無効化される", () => {
       mockUseRegisterUser.mockReturnValue({
         ...defaultHookReturn,
         isLoading: true,
@@ -235,7 +235,7 @@ describe("RegisterForm", () => {
       expect(submitButton).toBeDisabled();
     });
 
-    it("isLoadingがtrueの時、フォームフィールドが無効化される", () => {
+    it("ローディング中はフォームフィールドが無効化される", () => {
       mockUseRegisterUser.mockReturnValue({
         ...defaultHookReturn,
         isLoading: true,
@@ -255,7 +255,7 @@ describe("RegisterForm", () => {
   });
 
   describe("エラー表示", () => {
-    it("EMAIL_ALREADY_EXISTSエラーが表示される", () => {
+    it("メールアドレス重複エラーが表示される", () => {
       const error = new ApiError(
         "EMAIL_ALREADY_EXISTS",
         "Email already exists",
@@ -273,7 +273,7 @@ describe("RegisterForm", () => {
       ).toBeInTheDocument();
     });
 
-    it("VALIDATION_ERRORとdetailsが表示される", () => {
+    it("バリデーションエラーと詳細が表示される", () => {
       const error = new ApiError("VALIDATION_ERROR", "Validation failed", 400, [
         "email: 不正な形式です",
         "password: 短すぎます",
@@ -290,7 +290,7 @@ describe("RegisterForm", () => {
       expect(screen.getByText("password: 短すぎます")).toBeInTheDocument();
     });
 
-    it("INTERNAL_ERRORが表示される", () => {
+    it("内部エラーが表示される", () => {
       const error = new ApiError("INTERNAL_ERROR", "Internal error", 500);
       mockUseRegisterUser.mockReturnValue({
         ...defaultHookReturn,
@@ -306,7 +306,7 @@ describe("RegisterForm", () => {
   });
 
   describe("成功状態", () => {
-    it("isSuccessがtrueの時、成功メッセージが表示される", () => {
+    it("成功時に成功メッセージが表示される", () => {
       mockUseRegisterUser.mockReturnValue({
         ...defaultHookReturn,
         isSuccess: true,
@@ -317,7 +317,7 @@ describe("RegisterForm", () => {
       expect(screen.getByText("登録が完了しました")).toBeInTheDocument();
     });
 
-    it("register関数成功時にonSuccessコールバックが呼ばれる", async () => {
+    it("登録成功時にonSuccessコールバックが呼ばれる", async () => {
       // register関数が成功時にonSuccessを呼び出すようにモック
       const onSuccess = vi.fn();
       mockUseRegisterUser.mockImplementation(() => ({

--- a/frontend/src/features/auth/hooks/useRegisterUser.test.ts
+++ b/frontend/src/features/auth/hooks/useRegisterUser.test.ts
@@ -36,8 +36,8 @@ describe("useRegisterUser", () => {
     vi.resetAllMocks();
   });
 
-  describe("initial state", () => {
-    it("should have correct initial state", () => {
+  describe("初期状態", () => {
+    it("正しい初期状態を持つ", () => {
       const { result } = renderHook(() => useRegisterUser());
 
       expect(result.current.isLoading).toBe(false);
@@ -48,8 +48,8 @@ describe("useRegisterUser", () => {
     });
   });
 
-  describe("successful registration", () => {
-    it("should set isSuccess to true on successful registration", async () => {
+  describe("登録成功", () => {
+    it("登録成功時にisSuccessがtrueになる", async () => {
       mockRegisterUser.mockResolvedValueOnce({ userId: "user-123" });
 
       const { result } = renderHook(() => useRegisterUser());
@@ -68,7 +68,7 @@ describe("useRegisterUser", () => {
       expect(mockRegisterUser).toHaveBeenCalledTimes(1);
     });
 
-    it("should set isLoading to true during registration", async () => {
+    it("登録中はisLoadingがtrueになる", async () => {
       let resolvePromise: (value: { userId: string }) => void;
       const pendingPromise = new Promise<{ userId: string }>((resolve) => {
         resolvePromise = resolve;
@@ -95,8 +95,8 @@ describe("useRegisterUser", () => {
     });
   });
 
-  describe("validation error", () => {
-    it("should set error on validation error", async () => {
+  describe("バリデーションエラー", () => {
+    it("バリデーションエラー時にエラーが設定される", async () => {
       const validationError = new authApi.ApiError(
         "VALIDATION_ERROR",
         "Validation failed",
@@ -124,8 +124,8 @@ describe("useRegisterUser", () => {
     });
   });
 
-  describe("email already exists error", () => {
-    it("should set error when email already exists", async () => {
+  describe("メールアドレス重複エラー", () => {
+    it("メールアドレス重複時にエラーが設定される", async () => {
       const emailExistsError = new authApi.ApiError(
         "EMAIL_ALREADY_EXISTS",
         "Email already registered",
@@ -148,8 +148,8 @@ describe("useRegisterUser", () => {
     });
   });
 
-  describe("server error", () => {
-    it("should set error on server error", async () => {
+  describe("サーバーエラー", () => {
+    it("サーバーエラー時にエラーが設定される", async () => {
       const serverError = new authApi.ApiError(
         ERROR_CODE_INTERNAL_ERROR,
         "Internal server error",
@@ -171,7 +171,7 @@ describe("useRegisterUser", () => {
       });
     });
 
-    it("should handle unexpected error", async () => {
+    it("予期しないエラー時にINTERNAL_ERRORが設定される", async () => {
       mockRegisterUser.mockRejectedValueOnce(new Error("Network error"));
 
       const { result } = renderHook(() => useRegisterUser());
@@ -189,8 +189,8 @@ describe("useRegisterUser", () => {
     });
   });
 
-  describe("reset", () => {
-    it("should reset all state", async () => {
+  describe("リセット", () => {
+    it("全ての状態がリセットされる", async () => {
       const validationError = new authApi.ApiError(
         "VALIDATION_ERROR",
         "Validation failed",

--- a/frontend/src/routes/routes.test.tsx
+++ b/frontend/src/routes/routes.test.tsx
@@ -16,7 +16,7 @@ global.fetch = vi.fn(() =>
 );
 
 describe("ルーティング", () => {
-  describe("/register ルート", () => {
+  describe("/registerルート", () => {
     it("RegisterPageが表示される", async () => {
       const router = createMemoryRouter(routes, {
         initialEntries: ["/register"],
@@ -43,7 +43,7 @@ describe("ルーティング", () => {
     });
   });
 
-  describe("/ ルート", () => {
+  describe("/ルート", () => {
     it("HomePageが表示される", async () => {
       const router = createMemoryRouter(routes, {
         initialEntries: ["/"],


### PR DESCRIPTION
## Summary
- Backend: 13ファイルのテストケース名を日本語化（domain/vo, domain/entity）
- Frontend: 3ファイルのテストケース名を日本語化（auth hooks, components, routes）
- CLAUDE.md: テストケース名の日本語規約を追記

## Test plan
- [x] Build: Pass
- [x] Test: Pass

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)