### PR TITLE
feat(domain/entity): Record・RecordItem Entity実装

### DIFF
--- a/backend/domain/entity/helper.go
+++ b/backend/domain/entity/helper.go
@@ -1,0 +1,9 @@
+package entity
+
+// appendIfErr はerrがnilでない場合にスライスに追加するヘルパー関数
+func appendIfErr(errs []error, err error) []error {
+	if err != nil {
+		return append(errs, err)
+	}
+	return errs
+}

--- a/backend/domain/entity/record.go
+++ b/backend/domain/entity/record.go
@@ -1,0 +1,109 @@
+package entity
+
+import (
+	"time"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+)
+
+// Record はカロリー記録を表すエンティティ
+type Record struct {
+	id        vo.RecordID
+	userID    vo.UserID
+	eatenAt   vo.EatenAt
+	items     []RecordItem
+	createdAt time.Time
+}
+
+// NewRecord は新しいRecordを生成する
+func NewRecord(
+	userID vo.UserID,
+	eatenAtTime time.Time,
+	itemInputs []RecordItemInput,
+) (*Record, []error) {
+	var errs []error
+
+	if len(itemInputs) == 0 {
+		errs = append(errs, domainErrors.ErrRecordItemsRequired)
+		return nil, errs
+	}
+
+	eatenAt, err := vo.NewEatenAt(eatenAtTime)
+	errs = appendIfErr(errs, err)
+
+	recordID := vo.NewRecordID()
+
+	var items []RecordItem
+	for _, input := range itemInputs {
+		item, itemErrs := newRecordItem(recordID, input)
+		if len(itemErrs) > 0 {
+			errs = append(errs, itemErrs...)
+		} else {
+			items = append(items, *item)
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return &Record{
+		id:        recordID,
+		userID:    userID,
+		eatenAt:   eatenAt,
+		items:     items,
+		createdAt: time.Now(),
+	}, nil
+}
+
+// ReconstructRecord はDBからRecordを復元する
+func ReconstructRecord(
+	idStr string,
+	userIDStr string,
+	eatenAtTime time.Time,
+	createdAt time.Time,
+	items []RecordItem,
+) *Record {
+	return &Record{
+		id:        vo.ReconstructRecordID(idStr),
+		userID:    vo.ReconstructUserID(userIDStr),
+		eatenAt:   vo.ReconstructEatenAt(eatenAtTime),
+		items:     items,
+		createdAt: createdAt,
+	}
+}
+
+// ID はRecordIDを返す
+func (r *Record) ID() vo.RecordID {
+	return r.id
+}
+
+// UserID はユーザーIDを返す
+func (r *Record) UserID() vo.UserID {
+	return r.userID
+}
+
+// EatenAt は食事日時を返す
+func (r *Record) EatenAt() vo.EatenAt {
+	return r.eatenAt
+}
+
+// Items は記録明細リストを返す
+func (r *Record) Items() []RecordItem {
+	return r.items
+}
+
+// CreatedAt は作成日時を返す
+func (r *Record) CreatedAt() time.Time {
+	return r.createdAt
+}
+
+// TotalCalories は記録の合計カロリーを返す
+func (r *Record) TotalCalories() int {
+	total := 0
+	for _, item := range r.items {
+		total += item.Calories().Value()
+	}
+	return total
+}

--- a/backend/domain/entity/record_item.go
+++ b/backend/domain/entity/record_item.go
@@ -1,0 +1,76 @@
+package entity
+
+import (
+	"caltrack/domain/vo"
+)
+
+// RecordItem はカロリー記録の明細を表すエンティティ
+type RecordItem struct {
+	id       vo.RecordItemID
+	recordID vo.RecordID
+	name     vo.ItemName
+	calories vo.Calories
+}
+
+// RecordItemInput はRecordItem作成時の入力パラメータ
+type RecordItemInput struct {
+	Name     string
+	Calories int
+}
+
+// newRecordItem は新しいRecordItemを生成する（Record内部で使用）
+func newRecordItem(recordID vo.RecordID, input RecordItemInput) (*RecordItem, []error) {
+	var errs []error
+
+	name, err := vo.NewItemName(input.Name)
+	errs = appendIfErr(errs, err)
+
+	calories, err := vo.NewCalories(input.Calories)
+	errs = appendIfErr(errs, err)
+
+	if len(errs) > 0 {
+		return nil, errs
+	}
+
+	return &RecordItem{
+		id:       vo.NewRecordItemID(),
+		recordID: recordID,
+		name:     name,
+		calories: calories,
+	}, nil
+}
+
+// ReconstructRecordItem はDBからRecordItemを復元する
+func ReconstructRecordItem(
+	idStr string,
+	recordIDStr string,
+	nameStr string,
+	caloriesVal int,
+) *RecordItem {
+	return &RecordItem{
+		id:       vo.ReconstructRecordItemID(idStr),
+		recordID: vo.ReconstructRecordID(recordIDStr),
+		name:     vo.ReconstructItemName(nameStr),
+		calories: vo.ReconstructCalories(caloriesVal),
+	}
+}
+
+// ID はRecordItemIDを返す
+func (ri *RecordItem) ID() vo.RecordItemID {
+	return ri.id
+}
+
+// RecordID は親のRecordIDを返す
+func (ri *RecordItem) RecordID() vo.RecordID {
+	return ri.recordID
+}
+
+// Name は食品名を返す
+func (ri *RecordItem) Name() vo.ItemName {
+	return ri.name
+}
+
+// Calories はカロリーを返す
+func (ri *RecordItem) Calories() vo.Calories {
+	return ri.calories
+}

--- a/backend/domain/entity/record_test.go
+++ b/backend/domain/entity/record_test.go
@@ -1,0 +1,213 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+)
+
+func TestNewRecord_正常系_有効なパラメータでRecord作成(t *testing.T) {
+	userID := vo.NewUserID()
+	eatenAt := time.Now().Add(-1 * time.Hour)
+	items := []entity.RecordItemInput{
+		{Name: "おにぎり", Calories: 180},
+		{Name: "味噌汁", Calories: 50},
+	}
+
+	record, errs := entity.NewRecord(userID, eatenAt, items)
+
+	if len(errs) > 0 {
+		t.Fatalf("NewRecord() unexpected errors = %v", errs)
+	}
+	if record == nil {
+		t.Fatal("NewRecord() returned nil record")
+	}
+	if !record.UserID().Equals(userID) {
+		t.Errorf("NewRecord().UserID() = %v, want %v", record.UserID(), userID)
+	}
+	if len(record.Items()) != 2 {
+		t.Errorf("NewRecord().Items() length = %d, want %d", len(record.Items()), 2)
+	}
+	if record.ID().String() == "" {
+		t.Error("NewRecord().ID() should not be empty")
+	}
+}
+
+func TestNewRecord_異常系_itemsが空の場合エラー(t *testing.T) {
+	userID := vo.NewUserID()
+	eatenAt := time.Now().Add(-1 * time.Hour)
+	items := []entity.RecordItemInput{}
+
+	record, errs := entity.NewRecord(userID, eatenAt, items)
+
+	if record != nil {
+		t.Error("NewRecord() should return nil when items is empty")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("NewRecord() errors count = %d, want 1", len(errs))
+	}
+	if errs[0] != domainErrors.ErrRecordItemsRequired {
+		t.Errorf("NewRecord() error = %v, want %v", errs[0], domainErrors.ErrRecordItemsRequired)
+	}
+}
+
+func TestNewRecord_異常系_未来の日時の場合エラー(t *testing.T) {
+	userID := vo.NewUserID()
+	eatenAt := time.Now().Add(1 * time.Hour) // 未来の日時
+	items := []entity.RecordItemInput{
+		{Name: "おにぎり", Calories: 180},
+	}
+
+	record, errs := entity.NewRecord(userID, eatenAt, items)
+
+	if record != nil {
+		t.Error("NewRecord() should return nil for future eaten_at")
+	}
+	if len(errs) != 1 {
+		t.Fatalf("NewRecord() errors count = %d, want 1", len(errs))
+	}
+	if errs[0] != domainErrors.ErrEatenAtMustNotBeFuture {
+		t.Errorf("NewRecord() error = %v, want %v", errs[0], domainErrors.ErrEatenAtMustNotBeFuture)
+	}
+}
+
+func TestNewRecord_異常系_無効なRecordItemの場合エラー(t *testing.T) {
+	userID := vo.NewUserID()
+	eatenAt := time.Now().Add(-1 * time.Hour)
+
+	tests := []struct {
+		name      string
+		items     []entity.RecordItemInput
+		wantErr   error
+		errCount  int
+	}{
+		{
+			name:      "食品名が空の場合",
+			items:     []entity.RecordItemInput{{Name: "", Calories: 180}},
+			wantErr:   domainErrors.ErrItemNameRequired,
+			errCount:  1,
+		},
+		{
+			name:      "カロリーが0以下の場合",
+			items:     []entity.RecordItemInput{{Name: "おにぎり", Calories: 0}},
+			wantErr:   domainErrors.ErrCaloriesMustBePositive,
+			errCount:  1,
+		},
+		{
+			name:      "食品名とカロリー両方無効の場合",
+			items:     []entity.RecordItemInput{{Name: "", Calories: -1}},
+			wantErr:   nil, // 複数エラー
+			errCount:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record, errs := entity.NewRecord(userID, eatenAt, tt.items)
+
+			if record != nil {
+				t.Error("NewRecord() should return nil for invalid items")
+			}
+			if len(errs) != tt.errCount {
+				t.Errorf("NewRecord() errors count = %d, want %d", len(errs), tt.errCount)
+			}
+			if tt.wantErr != nil && errs[0] != tt.wantErr {
+				t.Errorf("NewRecord() error = %v, want %v", errs[0], tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReconstructRecord_DB復元(t *testing.T) {
+	idStr := "record-123"
+	userIDStr := "user-456"
+	eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
+	items := []entity.RecordItem{
+		*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
+		*entity.ReconstructRecordItem("item-2", idStr, "味噌汁", 50),
+	}
+
+	record := entity.ReconstructRecord(idStr, userIDStr, eatenAtTime, createdAt, items)
+
+	if record.ID().String() != idStr {
+		t.Errorf("ReconstructRecord().ID() = %v, want %v", record.ID().String(), idStr)
+	}
+	if record.UserID().String() != userIDStr {
+		t.Errorf("ReconstructRecord().UserID() = %v, want %v", record.UserID().String(), userIDStr)
+	}
+	if !record.EatenAt().Time().Equal(eatenAtTime) {
+		t.Errorf("ReconstructRecord().EatenAt() = %v, want %v", record.EatenAt().Time(), eatenAtTime)
+	}
+	if !record.CreatedAt().Equal(createdAt) {
+		t.Errorf("ReconstructRecord().CreatedAt() = %v, want %v", record.CreatedAt(), createdAt)
+	}
+	if len(record.Items()) != 2 {
+		t.Errorf("ReconstructRecord().Items() length = %d, want %d", len(record.Items()), 2)
+	}
+}
+
+func TestRecord_TotalCalories_合計カロリー計算(t *testing.T) {
+	idStr := "record-123"
+	userIDStr := "user-456"
+	eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+	createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		items    []entity.RecordItem
+		wantTotal int
+	}{
+		{
+			name: "単一アイテム",
+			items: []entity.RecordItem{
+				*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
+			},
+			wantTotal: 180,
+		},
+		{
+			name: "複数アイテム",
+			items: []entity.RecordItem{
+				*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
+				*entity.ReconstructRecordItem("item-2", idStr, "味噌汁", 50),
+				*entity.ReconstructRecordItem("item-3", idStr, "焼き鮭", 200),
+			},
+			wantTotal: 430,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			record := entity.ReconstructRecord(idStr, userIDStr, eatenAtTime, createdAt, tt.items)
+
+			if got := record.TotalCalories(); got != tt.wantTotal {
+				t.Errorf("TotalCalories() = %d, want %d", got, tt.wantTotal)
+			}
+		})
+	}
+}
+
+func TestReconstructRecordItem_DB復元(t *testing.T) {
+	idStr := "item-123"
+	recordIDStr := "record-456"
+	nameStr := "おにぎり"
+	caloriesVal := 180
+
+	item := entity.ReconstructRecordItem(idStr, recordIDStr, nameStr, caloriesVal)
+
+	if item.ID().String() != idStr {
+		t.Errorf("ReconstructRecordItem().ID() = %v, want %v", item.ID().String(), idStr)
+	}
+	if item.RecordID().String() != recordIDStr {
+		t.Errorf("ReconstructRecordItem().RecordID() = %v, want %v", item.RecordID().String(), recordIDStr)
+	}
+	if item.Name().String() != nameStr {
+		t.Errorf("ReconstructRecordItem().Name() = %v, want %v", item.Name().String(), nameStr)
+	}
+	if item.Calories().Value() != caloriesVal {
+		t.Errorf("ReconstructRecordItem().Calories() = %v, want %v", item.Calories().Value(), caloriesVal)
+	}
+}

--- a/backend/domain/entity/user.go
+++ b/backend/domain/entity/user.go
@@ -32,10 +32,10 @@ func NewUser(
 ) (*User, []error) {
 	var errs []error
 
-	email, err := parseEmail(emailStr)
+	email, err := vo.NewEmail(emailStr)
 	errs = appendIfErr(errs, err)
 
-	password, err := parsePassword(passwordStr)
+	password, err := vo.NewPassword(passwordStr)
 	errs = appendIfErr(errs, err)
 
 	var hashedPassword vo.HashedPassword
@@ -46,22 +46,22 @@ func NewUser(
 		}
 	}
 
-	nickname, err := parseNickname(nicknameStr)
+	nickname, err := vo.NewNickname(nicknameStr)
 	errs = appendIfErr(errs, err)
 
-	weight, err := parseWeight(weightVal)
+	weight, err := vo.NewWeight(weightVal)
 	errs = appendIfErr(errs, err)
 
-	height, err := parseHeight(heightVal)
+	height, err := vo.NewHeight(heightVal)
 	errs = appendIfErr(errs, err)
 
-	birthDate, err := parseBirthDate(birthDateVal)
+	birthDate, err := vo.NewBirthDate(birthDateVal)
 	errs = appendIfErr(errs, err)
 
-	gender, err := parseGender(genderStr)
+	gender, err := vo.NewGender(genderStr)
 	errs = appendIfErr(errs, err)
 
-	activityLevel, err := parseActivityLevel(activityLevelStr)
+	activityLevel, err := vo.NewActivityLevel(activityLevelStr)
 	errs = appendIfErr(errs, err)
 
 	if len(errs) > 0 {
@@ -82,45 +82,6 @@ func NewUser(
 		createdAt:      now,
 		updatedAt:      now,
 	}, nil
-}
-
-func appendIfErr(errs []error, err error) []error {
-	if err != nil {
-		return append(errs, err)
-	}
-	return errs
-}
-
-func parseEmail(s string) (vo.Email, error) {
-	return vo.NewEmail(s)
-}
-
-func parsePassword(s string) (vo.Password, error) {
-	return vo.NewPassword(s)
-}
-
-func parseNickname(s string) (vo.Nickname, error) {
-	return vo.NewNickname(s)
-}
-
-func parseWeight(v float64) (vo.Weight, error) {
-	return vo.NewWeight(v)
-}
-
-func parseHeight(v float64) (vo.Height, error) {
-	return vo.NewHeight(v)
-}
-
-func parseBirthDate(v time.Time) (vo.BirthDate, error) {
-	return vo.NewBirthDate(v)
-}
-
-func parseGender(s string) (vo.Gender, error) {
-	return vo.NewGender(s)
-}
-
-func parseActivityLevel(s string) (vo.ActivityLevel, error) {
-	return vo.NewActivityLevel(s)
 }
 
 // ReconstructUser はDBからの復元用。

--- a/backend/domain/entity/user_test.go
+++ b/backend/domain/entity/user_test.go
@@ -127,4 +127,3 @@ func TestReconstructUser_Success(t *testing.T) {
 		t.Errorf("UpdatedAt = %v, want %v", user.UpdatedAt(), updatedAt)
 	}
 }
-

--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -3,23 +3,23 @@ package errors
 import "errors"
 
 var (
-	ErrEmailRequired        = errors.New("email is required")
-	ErrInvalidEmailFormat   = errors.New("invalid email format")
-	ErrEmailTooLong         = errors.New("email must be 254 characters or less")
-	ErrPasswordRequired     = errors.New("password is required")
-	ErrPasswordTooShort     = errors.New("password must be at least 8 characters")
-	ErrNicknameRequired     = errors.New("nickname is required")
-	ErrNicknameTooLong      = errors.New("nickname must be 50 characters or less")
-	ErrWeightMustBePositive = errors.New("weight must be positive")
-	ErrWeightTooHeavy       = errors.New("weight must be 500kg or less")
-	ErrHeightMustBePositive = errors.New("height must be positive")
-	ErrHeightTooTall        = errors.New("height must be 300cm or less")
-	ErrBirthDateMustBePast      = errors.New("birth date must be in the past")
-	ErrBirthDateTooOld          = errors.New("birth date must be within 150 years")
-	ErrEatenAtMustNotBeFuture   = errors.New("eaten at must not be in the future")
-	ErrCaloriesMustBePositive   = errors.New("calories must be positive")
-	ErrInvalidGender        = errors.New("gender must be male, female, or other")
-	ErrInvalidActivityLevel = errors.New("activity level must be sedentary, light, moderate, active, or veryActive")
+	ErrEmailRequired          = errors.New("email is required")
+	ErrInvalidEmailFormat     = errors.New("invalid email format")
+	ErrEmailTooLong           = errors.New("email must be 254 characters or less")
+	ErrPasswordRequired       = errors.New("password is required")
+	ErrPasswordTooShort       = errors.New("password must be at least 8 characters")
+	ErrNicknameRequired       = errors.New("nickname is required")
+	ErrNicknameTooLong        = errors.New("nickname must be 50 characters or less")
+	ErrWeightMustBePositive   = errors.New("weight must be positive")
+	ErrWeightTooHeavy         = errors.New("weight must be 500kg or less")
+	ErrHeightMustBePositive   = errors.New("height must be positive")
+	ErrHeightTooTall          = errors.New("height must be 300cm or less")
+	ErrBirthDateMustBePast    = errors.New("birth date must be in the past")
+	ErrBirthDateTooOld        = errors.New("birth date must be within 150 years")
+	ErrEatenAtMustNotBeFuture = errors.New("eaten at must not be in the future")
+	ErrCaloriesMustBePositive = errors.New("calories must be positive")
+	ErrInvalidGender          = errors.New("gender must be male, female, or other")
+	ErrInvalidActivityLevel   = errors.New("activity level must be sedentary, light, moderate, active, or veryActive")
 
 	// Usecase errors
 	ErrEmailAlreadyExists = errors.New("email already exists")
@@ -36,4 +36,7 @@ var (
 
 	// Record Item errors
 	ErrItemNameRequired = errors.New("item name is required")
+
+	// Record errors
+	ErrRecordItemsRequired = errors.New("at least one record item is required")
 )

--- a/backend/domain/vo/eaten_at.go
+++ b/backend/domain/vo/eaten_at.go
@@ -6,6 +6,35 @@ import (
 	domainErrors "caltrack/domain/errors"
 )
 
+// MealType は食事タイプを表す
+type MealType int
+
+const (
+	MealTypeBreakfast MealType = iota + 1 // 朝食 (5:00 - 11:00)
+	MealTypeLunch                         // 昼食 (11:00 - 14:00)
+	MealTypeSnack                         // 間食 (14:00 - 17:00)
+	MealTypeDinner                        // 夕食 (17:00 - 21:00)
+	MealTypeLateNight                     // 夜食 (21:00 - 5:00)
+)
+
+// String は食事タイプの日本語名を返す
+func (m MealType) String() string {
+	switch m {
+	case MealTypeBreakfast:
+		return "朝食"
+	case MealTypeLunch:
+		return "昼食"
+	case MealTypeSnack:
+		return "間食"
+	case MealTypeDinner:
+		return "夕食"
+	case MealTypeLateNight:
+		return "夜食"
+	default:
+		return "不明"
+	}
+}
+
 // EatenAt はカロリー記録の食事日時を表す値オブジェクト
 type EatenAt struct {
 	value time.Time
@@ -34,4 +63,22 @@ func (e EatenAt) Time() time.Time {
 // Equals は2つのEatenAtが等しいかを比較する
 func (e EatenAt) Equals(other EatenAt) bool {
 	return e.value.Equal(other.value)
+}
+
+// MealType は食事日時から食事タイプを判定して返す
+func (e EatenAt) MealType() MealType {
+	hour := e.value.Hour()
+
+	switch {
+	case hour >= 5 && hour < 11:
+		return MealTypeBreakfast
+	case hour >= 11 && hour < 14:
+		return MealTypeLunch
+	case hour >= 14 && hour < 17:
+		return MealTypeSnack
+	case hour >= 17 && hour < 21:
+		return MealTypeDinner
+	default:
+		return MealTypeLateNight
+	}
 }

--- a/backend/domain/vo/eaten_at_test.go
+++ b/backend/domain/vo/eaten_at_test.go
@@ -87,3 +87,50 @@ func TestEatenAt_Equals(t *testing.T) {
 		})
 	}
 }
+
+func TestEatenAt_MealType(t *testing.T) {
+	tests := []struct {
+		name     string
+		hour     int
+		wantType MealType
+		wantName string
+	}{
+		// 朝食 (5:00 - 11:00)
+		{"5時は朝食", 5, MealTypeBreakfast, "朝食"},
+		{"10時は朝食", 10, MealTypeBreakfast, "朝食"},
+		// 昼食 (11:00 - 14:00)
+		{"11時は昼食", 11, MealTypeLunch, "昼食"},
+		{"13時は昼食", 13, MealTypeLunch, "昼食"},
+		// 間食 (14:00 - 17:00)
+		{"14時は間食", 14, MealTypeSnack, "間食"},
+		{"16時は間食", 16, MealTypeSnack, "間食"},
+		// 夕食 (17:00 - 21:00)
+		{"17時は夕食", 17, MealTypeDinner, "夕食"},
+		{"20時は夕食", 20, MealTypeDinner, "夕食"},
+		// 夜食 (21:00 - 5:00)
+		{"21時は夜食", 21, MealTypeLateNight, "夜食"},
+		{"0時は夜食", 0, MealTypeLateNight, "夜食"},
+		{"4時は夜食", 4, MealTypeLateNight, "夜食"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eatenAt := ReconstructEatenAt(time.Date(2024, 6, 15, tt.hour, 0, 0, 0, time.UTC))
+
+			if got := eatenAt.MealType(); got != tt.wantType {
+				t.Errorf("MealType() = %v, want %v", got, tt.wantType)
+			}
+			if got := eatenAt.MealType().String(); got != tt.wantName {
+				t.Errorf("MealType().String() = %v, want %v", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestMealType_String_不明な値(t *testing.T) {
+	// 定義されていないMealType値の場合
+	invalidType := MealType(99)
+	if got := invalidType.String(); got != "不明" {
+		t.Errorf("MealType(99).String() = %v, want %v", got, "不明")
+	}
+}


### PR DESCRIPTION
## Summary
- Record Entity（カロリー記録）の実装
- RecordItem Entity（記録アイテム）の実装
- EatenAt VOにMealType追加
- helper.goでEntity生成ヘルパー関数追加
- user.goのparse関数削除・vo.New直接呼び出し化
- ドメインエラー定数追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass (97 tests)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)