### PR TITLE
refactor(domain/entity): Record EntityのAPI改善

### DIFF
--- a/backend/domain/entity/record_item.go
+++ b/backend/domain/entity/record_item.go
@@ -12,20 +12,14 @@ type RecordItem struct {
 	calories vo.Calories
 }
 
-// RecordItemInput はRecordItem作成時の入力パラメータ
-type RecordItemInput struct {
-	Name     string
-	Calories int
-}
-
-// newRecordItem は新しいRecordItemを生成する（Record内部で使用）
-func newRecordItem(recordID vo.RecordID, input RecordItemInput) (*RecordItem, []error) {
+// NewRecordItem は新しいRecordItemを生成する
+func NewRecordItem(recordID vo.RecordID, nameStr string, caloriesVal int) (*RecordItem, []error) {
 	var errs []error
 
-	name, err := vo.NewItemName(input.Name)
+	name, err := vo.NewItemName(nameStr)
 	errs = appendIfErr(errs, err)
 
-	calories, err := vo.NewCalories(input.Calories)
+	calories, err := vo.NewCalories(caloriesVal)
 	errs = appendIfErr(errs, err)
 
 	if len(errs) > 0 {

--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -36,7 +36,4 @@ var (
 
 	// Record Item errors
 	ErrItemNameRequired = errors.New("item name is required")
-
-	// Record errors
-	ErrRecordItemsRequired = errors.New("at least one record item is required")
 )


### PR DESCRIPTION
## Summary
- `RecordItemInput`構造体を削除
- `newRecordItem` → `NewRecordItem`に変更（公開関数化）
- `NewRecord`の引数からitemsを削除し、`AddItem`メソッドで追加する方式に変更
- `ErrRecordItemsRequired`エラー定数削除
- テストを新APIに合わせて修正

## Test plan
- [x] Build: Pass
- [x] Test: Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)