### PR TITLE
feat(storybook): shadcn/ui・authコンポーネントのStory追加

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -2,6 +2,9 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: [
+    // components/ui配下のストーリーを対象（shadcn/ui）
+    '../src/components/ui/**/*.mdx',
+    '../src/components/ui/**/*.stories.@(js|jsx|mjs|ts|tsx)',
     // features配下のストーリーを対象
     '../src/features/**/*.mdx',
     '../src/features/**/*.stories.@(js|jsx|mjs|ts|tsx)',

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,4 +1,6 @@
 import type { Preview } from '@storybook/react-vite';
+import { MemoryRouter } from 'react-router-dom';
+import React from 'react';
 
 // グローバルCSSの読み込み（Tailwind CSS）
 import '../src/index.css';
@@ -12,6 +14,12 @@ const preview: Preview = {
       },
     },
   },
+  // React Router対応のデコレータ
+  decorators: [
+    (Story) => (
+      React.createElement(MemoryRouter, null, React.createElement(Story))
+    ),
+  ],
 };
 
 export default preview;

--- a/frontend/src/components/ui/button.stories.tsx
+++ b/frontend/src/components/ui/button.stories.tsx
@@ -1,0 +1,129 @@
+/**
+ * Button コンポーネントのStorybook
+ * 各バリアント・サイズ・状態の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Button } from './button';
+
+const meta: Meta<typeof Button> = {
+  title: 'UI/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
+      description: 'ボタンのスタイルバリアント',
+    },
+    size: {
+      control: 'select',
+      options: ['default', 'sm', 'lg', 'icon'],
+      description: 'ボタンのサイズ',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '無効化状態',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Button>;
+
+/** デフォルトボタン */
+export const Default: Story = {
+  args: {
+    children: 'ボタン',
+    variant: 'default',
+    size: 'default',
+  },
+};
+
+/** 破壊的アクション用ボタン */
+export const Destructive: Story = {
+  args: {
+    children: '削除',
+    variant: 'destructive',
+  },
+};
+
+/** アウトラインボタン */
+export const Outline: Story = {
+  args: {
+    children: 'アウトライン',
+    variant: 'outline',
+  },
+};
+
+/** セカンダリボタン */
+export const Secondary: Story = {
+  args: {
+    children: 'セカンダリ',
+    variant: 'secondary',
+  },
+};
+
+/** ゴーストボタン */
+export const Ghost: Story = {
+  args: {
+    children: 'ゴースト',
+    variant: 'ghost',
+  },
+};
+
+/** リンクスタイルボタン */
+export const Link: Story = {
+  args: {
+    children: 'リンク',
+    variant: 'link',
+  },
+};
+
+/** 小サイズボタン */
+export const Small: Story = {
+  args: {
+    children: '小サイズ',
+    size: 'sm',
+  },
+};
+
+/** 大サイズボタン */
+export const Large: Story = {
+  args: {
+    children: '大サイズ',
+    size: 'lg',
+  },
+};
+
+/** 無効化状態 */
+export const Disabled: Story = {
+  args: {
+    children: '無効',
+    disabled: true,
+  },
+};
+
+/** 全バリアント一覧 */
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      <Button variant="default">Default</Button>
+      <Button variant="destructive">Destructive</Button>
+      <Button variant="outline">Outline</Button>
+      <Button variant="secondary">Secondary</Button>
+      <Button variant="ghost">Ghost</Button>
+      <Button variant="link">Link</Button>
+    </div>
+  ),
+};
+
+/** 全サイズ一覧 */
+export const AllSizes: Story = {
+  render: () => (
+    <div className="flex items-center gap-4">
+      <Button size="sm">Small</Button>
+      <Button size="default">Default</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/card.stories.tsx
+++ b/frontend/src/components/ui/card.stories.tsx
@@ -1,0 +1,129 @@
+/**
+ * Card コンポーネントのStorybook
+ * カード全体および各サブコンポーネントの表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+} from './card';
+import { Button } from './button';
+
+const meta: Meta<typeof Card> = {
+  title: 'UI/Card',
+  component: Card,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+/** 基本的なカード */
+export const Default: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>カードタイトル</CardTitle>
+        <CardDescription>カードの説明文がここに入ります</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>カードの本文コンテンツです。</p>
+      </CardContent>
+      <CardFooter>
+        <Button>アクション</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+/** ヘッダーのみ */
+export const HeaderOnly: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>タイトルのみ</CardTitle>
+      </CardHeader>
+    </Card>
+  ),
+};
+
+/** ヘッダー + 説明文 */
+export const WithDescription: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>タイトル</CardTitle>
+        <CardDescription>
+          これはカードの説明文です。補足情報を記載します。
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  ),
+};
+
+/** コンテンツのみ */
+export const ContentOnly: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardContent className="pt-6">
+        <p>コンテンツのみのカードです。</p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+/** フッター付きカード */
+export const WithFooter: Story = {
+  render: () => (
+    <Card className="w-[350px]">
+      <CardHeader>
+        <CardTitle>確認</CardTitle>
+        <CardDescription>この操作を実行しますか？</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p>操作の詳細説明がここに入ります。</p>
+      </CardContent>
+      <CardFooter className="flex justify-end gap-2">
+        <Button variant="outline">キャンセル</Button>
+        <Button>確認</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+/** フォームカード例 */
+export const FormCard: Story = {
+  render: () => (
+    <Card className="w-[400px]">
+      <CardHeader>
+        <CardTitle>ログイン</CardTitle>
+        <CardDescription>アカウントにログインしてください</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm font-medium">メールアドレス</label>
+          <input
+            type="email"
+            placeholder="example@example.com"
+            className="w-full h-10 px-3 border rounded-md"
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="text-sm font-medium">パスワード</label>
+          <input
+            type="password"
+            placeholder="パスワード"
+            className="w-full h-10 px-3 border rounded-md"
+          />
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Button className="w-full">ログイン</Button>
+      </CardFooter>
+    </Card>
+  ),
+};

--- a/frontend/src/components/ui/input.stories.tsx
+++ b/frontend/src/components/ui/input.stories.tsx
@@ -1,0 +1,134 @@
+/**
+ * Input コンポーネントのStorybook
+ * 各種入力タイプと状態の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Input } from './input';
+import { Label } from './label';
+
+const meta: Meta<typeof Input> = {
+  title: 'UI/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'password', 'number', 'date', 'search'],
+      description: '入力タイプ',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '無効化状態',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'プレースホルダー',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+/** テキスト入力 */
+export const Text: Story = {
+  args: {
+    type: 'text',
+    placeholder: 'テキストを入力',
+  },
+};
+
+/** メールアドレス入力 */
+export const Email: Story = {
+  args: {
+    type: 'email',
+    placeholder: 'example@example.com',
+  },
+};
+
+/** パスワード入力 */
+export const Password: Story = {
+  args: {
+    type: 'password',
+    placeholder: 'パスワードを入力',
+  },
+};
+
+/** 数値入力 */
+export const Number: Story = {
+  args: {
+    type: 'number',
+    placeholder: '0',
+  },
+};
+
+/** 日付入力 */
+export const Date: Story = {
+  args: {
+    type: 'date',
+  },
+};
+
+/** 無効化状態 */
+export const Disabled: Story = {
+  args: {
+    type: 'text',
+    placeholder: '入力不可',
+    disabled: true,
+  },
+};
+
+/** エラー状態 */
+export const WithError: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Label htmlFor="error-input">メールアドレス</Label>
+      <Input
+        id="error-input"
+        type="email"
+        placeholder="example@example.com"
+        aria-invalid="true"
+        className="border-destructive focus-visible:ring-destructive"
+      />
+      <p className="text-sm text-destructive">正しいメールアドレスを入力してください</p>
+    </div>
+  ),
+};
+
+/** ラベル付き */
+export const WithLabel: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Label htmlFor="labeled-input">ニックネーム</Label>
+      <Input id="labeled-input" type="text" placeholder="ニックネームを入力" />
+    </div>
+  ),
+};
+
+/** 全タイプ一覧 */
+export const AllTypes: Story = {
+  render: () => (
+    <div className="space-y-4 w-[300px]">
+      <div className="space-y-2">
+        <Label>テキスト</Label>
+        <Input type="text" placeholder="テキスト" />
+      </div>
+      <div className="space-y-2">
+        <Label>メール</Label>
+        <Input type="email" placeholder="example@example.com" />
+      </div>
+      <div className="space-y-2">
+        <Label>パスワード</Label>
+        <Input type="password" placeholder="パスワード" />
+      </div>
+      <div className="space-y-2">
+        <Label>数値</Label>
+        <Input type="number" placeholder="0" />
+      </div>
+      <div className="space-y-2">
+        <Label>日付</Label>
+        <Input type="date" />
+      </div>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/label.stories.tsx
+++ b/frontend/src/components/ui/label.stories.tsx
@@ -1,0 +1,73 @@
+/**
+ * Label コンポーネントのStorybook
+ * フォームラベルの表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Label } from './label';
+import { Input } from './input';
+
+const meta: Meta<typeof Label> = {
+  title: 'UI/Label',
+  component: Label,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+/** 基本的なラベル */
+export const Default: Story = {
+  args: {
+    children: 'ラベル',
+  },
+};
+
+/** 入力フィールドと組み合わせ */
+export const WithInput: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Label htmlFor="email">メールアドレス</Label>
+      <Input id="email" type="email" placeholder="example@example.com" />
+    </div>
+  ),
+};
+
+/** 必須項目 */
+export const Required: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Label htmlFor="name">
+        名前 <span className="text-destructive">*</span>
+      </Label>
+      <Input id="name" type="text" placeholder="名前を入力" />
+    </div>
+  ),
+};
+
+/** 無効化されたフィールドのラベル */
+export const DisabledField: Story = {
+  render: () => (
+    <div className="space-y-2">
+      <Label htmlFor="disabled-input" className="peer-disabled:opacity-70">
+        無効化されたフィールド
+      </Label>
+      <Input id="disabled-input" type="text" disabled placeholder="入力不可" />
+    </div>
+  ),
+};
+
+/** 複数フィールド */
+export const MultipleFields: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="username">ユーザー名</Label>
+        <Input id="username" type="text" placeholder="ユーザー名" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="password">パスワード</Label>
+        <Input id="password" type="password" placeholder="パスワード" />
+      </div>
+    </div>
+  ),
+};

--- a/frontend/src/components/ui/select.stories.tsx
+++ b/frontend/src/components/ui/select.stories.tsx
@@ -1,0 +1,129 @@
+/**
+ * Select コンポーネントのStorybook
+ * ドロップダウン選択の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Select, SelectOption } from './select';
+import { Label } from './label';
+
+const meta: Meta<typeof Select> = {
+  title: 'UI/Select',
+  component: Select,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: '無効化状態',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+/** 基本的なセレクト */
+export const Default: Story = {
+  render: () => (
+    <Select>
+      <SelectOption value="">選択してください</SelectOption>
+      <SelectOption value="1">オプション1</SelectOption>
+      <SelectOption value="2">オプション2</SelectOption>
+      <SelectOption value="3">オプション3</SelectOption>
+    </Select>
+  ),
+};
+
+/** ラベル付き */
+export const WithLabel: Story = {
+  render: () => (
+    <div className="space-y-2 w-[250px]">
+      <Label htmlFor="select-with-label">カテゴリー</Label>
+      <Select id="select-with-label">
+        <SelectOption value="">選択してください</SelectOption>
+        <SelectOption value="food">食品</SelectOption>
+        <SelectOption value="drink">飲料</SelectOption>
+        <SelectOption value="snack">お菓子</SelectOption>
+      </Select>
+    </div>
+  ),
+};
+
+/** 性別選択 */
+export const GenderSelect: Story = {
+  render: () => (
+    <div className="space-y-2 w-[250px]">
+      <Label htmlFor="gender">性別</Label>
+      <Select id="gender">
+        <SelectOption value="">選択してください</SelectOption>
+        <SelectOption value="male">男性</SelectOption>
+        <SelectOption value="female">女性</SelectOption>
+        <SelectOption value="other">その他</SelectOption>
+      </Select>
+    </div>
+  ),
+};
+
+/** 活動レベル選択 */
+export const ActivityLevelSelect: Story = {
+  render: () => (
+    <div className="space-y-2 w-[300px]">
+      <Label htmlFor="activity">活動レベル</Label>
+      <Select id="activity">
+        <SelectOption value="">選択してください</SelectOption>
+        <SelectOption value="sedentary">座りがち（運動なし）</SelectOption>
+        <SelectOption value="light">軽い（週1-3回運動）</SelectOption>
+        <SelectOption value="moderate">適度（週3-5回運動）</SelectOption>
+        <SelectOption value="active">活動的（週6-7回運動）</SelectOption>
+        <SelectOption value="veryActive">非常に活動的（毎日激しい運動）</SelectOption>
+      </Select>
+    </div>
+  ),
+};
+
+/** 無効化状態 */
+export const Disabled: Story = {
+  render: () => (
+    <div className="space-y-2 w-[250px]">
+      <Label htmlFor="disabled-select">無効化</Label>
+      <Select id="disabled-select" disabled>
+        <SelectOption value="">選択できません</SelectOption>
+        <SelectOption value="1">オプション1</SelectOption>
+      </Select>
+    </div>
+  ),
+};
+
+/** エラー状態 */
+export const WithError: Story = {
+  render: () => (
+    <div className="space-y-2 w-[250px]">
+      <Label htmlFor="error-select">性別</Label>
+      <Select
+        id="error-select"
+        aria-invalid="true"
+        className="border-destructive focus-visible:ring-destructive"
+      >
+        <SelectOption value="">選択してください</SelectOption>
+        <SelectOption value="male">男性</SelectOption>
+        <SelectOption value="female">女性</SelectOption>
+        <SelectOption value="other">その他</SelectOption>
+      </Select>
+      <p className="text-sm text-destructive">性別を選択してください</p>
+    </div>
+  ),
+};
+
+/** 選択済み */
+export const Preselected: Story = {
+  render: () => (
+    <div className="space-y-2 w-[250px]">
+      <Label htmlFor="preselected">性別</Label>
+      <Select id="preselected" defaultValue="female">
+        <SelectOption value="">選択してください</SelectOption>
+        <SelectOption value="male">男性</SelectOption>
+        <SelectOption value="female">女性</SelectOption>
+        <SelectOption value="other">その他</SelectOption>
+      </Select>
+    </div>
+  ),
+};

--- a/frontend/src/features/auth/components/LoginForm.stories.tsx
+++ b/frontend/src/features/auth/components/LoginForm.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * LoginForm コンポーネントのStorybook
+ * ログインフォームの各状態の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LoginForm } from './LoginForm';
+
+const meta: Meta<typeof LoginForm> = {
+  title: 'Auth/LoginForm',
+  component: LoginForm,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[400px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof LoginForm>;
+
+/** デフォルト状態 */
+export const Default: Story = {
+  args: {},
+};
+
+/** 成功コールバック付き */
+export const WithOnSuccess: Story = {
+  args: {
+    onSuccess: (response) => {
+      console.log('ログイン成功:', response);
+      alert('ログイン成功！');
+    },
+  },
+};

--- a/frontend/src/features/auth/components/LoginPage.stories.tsx
+++ b/frontend/src/features/auth/components/LoginPage.stories.tsx
@@ -1,0 +1,30 @@
+/**
+ * LoginPage コンポーネントのStorybook
+ * ログインページ全体の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { LoginPage } from './LoginPage';
+
+const meta: Meta<typeof LoginPage> = {
+  title: 'Auth/LoginPage',
+  component: LoginPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LoginPage>;
+
+/** デフォルト状態 */
+export const Default: Story = {
+  args: {},
+};
+
+/** カスタムリダイレクト先 */
+export const WithCustomRedirect: Story = {
+  args: {
+    redirectTo: '/dashboard',
+  },
+};

--- a/frontend/src/features/auth/components/RegisterForm.stories.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.stories.tsx
@@ -1,0 +1,40 @@
+/**
+ * RegisterForm コンポーネントのStorybook
+ * 新規登録フォームの各状態の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RegisterForm } from './RegisterForm';
+
+const meta: Meta<typeof RegisterForm> = {
+  title: 'Auth/RegisterForm',
+  component: RegisterForm,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[450px]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof RegisterForm>;
+
+/** デフォルト状態 */
+export const Default: Story = {
+  args: {},
+};
+
+/** 成功コールバック付き */
+export const WithOnSuccess: Story = {
+  args: {
+    onSuccess: () => {
+      console.log('登録成功');
+      alert('登録成功！');
+    },
+  },
+};

--- a/frontend/src/features/auth/components/RegisterPage.stories.tsx
+++ b/frontend/src/features/auth/components/RegisterPage.stories.tsx
@@ -1,0 +1,30 @@
+/**
+ * RegisterPage コンポーネントのStorybook
+ * 新規登録ページ全体の表示確認
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { RegisterPage } from './RegisterPage';
+
+const meta: Meta<typeof RegisterPage> = {
+  title: 'Auth/RegisterPage',
+  component: RegisterPage,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RegisterPage>;
+
+/** デフォルト状態 */
+export const Default: Story = {
+  args: {},
+};
+
+/** カスタムリダイレクト先 */
+export const WithCustomRedirect: Story = {
+  args: {
+    redirectTo: '/login',
+  },
+};


### PR DESCRIPTION
## Summary
- `.storybook/main.ts`にcomponents/ui/パスを追加
- `.storybook/preview.ts`にMemoryRouterデコレータを追加
- shadcn/uiコンポーネントのStory追加（Button, Card, Label, Input, Select）
- authコンポーネントのStory追加（LoginForm, LoginPage, RegisterForm, RegisterPage）

## Test plan
- [x] Storybook起動: 正常に起動
- [x] 各Story: 正常に表示

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)