### PR TITLE
feat(handler): カロリー記録のHandler層実装

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -13,12 +13,27 @@ paths:
 ## テスト命名
 
 ```
-Test{対象}_{条件}_{期待結果}
+Test{対象}_{メソッド名}
 ```
 
 例:
-- `TestNewEmail_ValidFormat_ReturnsEmail`
-- `TestUser_ChangePassword_UpdatesPassword`
+- `TestNewEmail`
+- `TestRecordHandler_Create`
+
+### サブテスト（t.Run）
+- t.Runを使用してサブテストを定義する
+- **テストケース名は日本語**で記述
+
+```go
+func TestRecordHandler_Create(t *testing.T) {
+    t.Run("正常系_記録が作成される", func(t *testing.T) {
+        // ...
+    })
+    t.Run("異常系_認証エラー", func(t *testing.T) {
+        // ...
+    })
+}
+```
 
 ## テーブル駆動テスト
 

--- a/backend/domain/entity/record_test.go
+++ b/backend/domain/entity/record_test.go
@@ -9,133 +9,139 @@ import (
 	"caltrack/domain/vo"
 )
 
-func TestNewRecord_正常系_有効なパラメータでRecord作成(t *testing.T) {
-	userID := vo.NewUserID()
-	eatenAt := time.Now().Add(-1 * time.Hour)
+func TestNewRecord(t *testing.T) {
+	t.Run("正常系_有効なパラメータでRecord作成", func(t *testing.T) {
+		userID := vo.NewUserID()
+		eatenAt := time.Now().Add(-1 * time.Hour)
 
-	record, err := entity.NewRecord(userID, eatenAt)
+		record, err := entity.NewRecord(userID, eatenAt)
 
-	if err != nil {
-		t.Fatalf("NewRecord() unexpected error = %v", err)
-	}
-	if record == nil {
-		t.Fatal("NewRecord() returned nil record")
-	}
-	if !record.UserID().Equals(userID) {
-		t.Errorf("NewRecord().UserID() = %v, want %v", record.UserID(), userID)
-	}
-	if len(record.Items()) != 0 {
-		t.Errorf("NewRecord().Items() length = %d, want %d", len(record.Items()), 0)
-	}
-	if record.ID().String() == "" {
-		t.Error("NewRecord().ID() should not be empty")
-	}
+		if err != nil {
+			t.Fatalf("NewRecord() unexpected error = %v", err)
+		}
+		if record == nil {
+			t.Fatal("NewRecord() returned nil record")
+		}
+		if !record.UserID().Equals(userID) {
+			t.Errorf("NewRecord().UserID() = %v, want %v", record.UserID(), userID)
+		}
+		if len(record.Items()) != 0 {
+			t.Errorf("NewRecord().Items() length = %d, want %d", len(record.Items()), 0)
+		}
+		if record.ID().String() == "" {
+			t.Error("NewRecord().ID() should not be empty")
+		}
+	})
+
+	t.Run("異常系_未来の日時の場合エラー", func(t *testing.T) {
+		userID := vo.NewUserID()
+		eatenAt := time.Now().Add(1 * time.Hour) // 未来の日時
+
+		record, err := entity.NewRecord(userID, eatenAt)
+
+		if record != nil {
+			t.Error("NewRecord() should return nil for future eaten_at")
+		}
+		if err != domainErrors.ErrEatenAtMustNotBeFuture {
+			t.Errorf("NewRecord() error = %v, want %v", err, domainErrors.ErrEatenAtMustNotBeFuture)
+		}
+	})
 }
 
-func TestNewRecord_異常系_未来の日時の場合エラー(t *testing.T) {
-	userID := vo.NewUserID()
-	eatenAt := time.Now().Add(1 * time.Hour) // 未来の日時
+func TestRecord_AddItem(t *testing.T) {
+	t.Run("正常系_アイテム追加", func(t *testing.T) {
+		userID := vo.NewUserID()
+		eatenAt := time.Now().Add(-1 * time.Hour)
+		record, _ := entity.NewRecord(userID, eatenAt)
 
-	record, err := entity.NewRecord(userID, eatenAt)
+		err := record.AddItem("おにぎり", 180)
 
-	if record != nil {
-		t.Error("NewRecord() should return nil for future eaten_at")
-	}
-	if err != domainErrors.ErrEatenAtMustNotBeFuture {
-		t.Errorf("NewRecord() error = %v, want %v", err, domainErrors.ErrEatenAtMustNotBeFuture)
-	}
+		if err != nil {
+			t.Fatalf("AddItem() unexpected error = %v", err)
+		}
+		if len(record.Items()) != 1 {
+			t.Errorf("AddItem() items count = %d, want %d", len(record.Items()), 1)
+		}
+		if record.Items()[0].Name().String() != "おにぎり" {
+			t.Errorf("AddItem() name = %v, want %v", record.Items()[0].Name().String(), "おにぎり")
+		}
+		if record.Items()[0].Calories().Value() != 180 {
+			t.Errorf("AddItem() calories = %v, want %v", record.Items()[0].Calories().Value(), 180)
+		}
+	})
+
+	t.Run("異常系_無効なアイテム", func(t *testing.T) {
+		userID := vo.NewUserID()
+		eatenAt := time.Now().Add(-1 * time.Hour)
+
+		tests := []struct {
+			name     string
+			itemName string
+			calories int
+			wantErr  error
+		}{
+			{
+				name:     "食品名が空の場合",
+				itemName: "",
+				calories: 180,
+				wantErr:  domainErrors.ErrItemNameRequired,
+			},
+			{
+				name:     "カロリーが0以下の場合",
+				itemName: "おにぎり",
+				calories: 0,
+				wantErr:  domainErrors.ErrCaloriesMustBePositive,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				record, _ := entity.NewRecord(userID, eatenAt)
+				err := record.AddItem(tt.itemName, tt.calories)
+
+				if err != tt.wantErr {
+					t.Errorf("AddItem() error = %v, want %v", err, tt.wantErr)
+				}
+				if len(record.Items()) != 0 {
+					t.Errorf("AddItem() should not add item on error, items count = %d", len(record.Items()))
+				}
+			})
+		}
+	})
 }
 
-func TestRecord_AddItem_正常系_アイテム追加(t *testing.T) {
-	userID := vo.NewUserID()
-	eatenAt := time.Now().Add(-1 * time.Hour)
-	record, _ := entity.NewRecord(userID, eatenAt)
+func TestReconstructRecord(t *testing.T) {
+	t.Run("DB復元", func(t *testing.T) {
+		idStr := "record-123"
+		userIDStr := "user-456"
+		eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
+		createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
+		items := []entity.RecordItem{
+			*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
+			*entity.ReconstructRecordItem("item-2", idStr, "味噌汁", 50),
+		}
 
-	err := record.AddItem("おにぎり", 180)
+		record := entity.ReconstructRecord(idStr, userIDStr, eatenAtTime, createdAt, items)
 
-	if err != nil {
-		t.Fatalf("AddItem() unexpected error = %v", err)
-	}
-	if len(record.Items()) != 1 {
-		t.Errorf("AddItem() items count = %d, want %d", len(record.Items()), 1)
-	}
-	if record.Items()[0].Name().String() != "おにぎり" {
-		t.Errorf("AddItem() name = %v, want %v", record.Items()[0].Name().String(), "おにぎり")
-	}
-	if record.Items()[0].Calories().Value() != 180 {
-		t.Errorf("AddItem() calories = %v, want %v", record.Items()[0].Calories().Value(), 180)
-	}
+		if record.ID().String() != idStr {
+			t.Errorf("ReconstructRecord().ID() = %v, want %v", record.ID().String(), idStr)
+		}
+		if record.UserID().String() != userIDStr {
+			t.Errorf("ReconstructRecord().UserID() = %v, want %v", record.UserID().String(), userIDStr)
+		}
+		if !record.EatenAt().Time().Equal(eatenAtTime) {
+			t.Errorf("ReconstructRecord().EatenAt() = %v, want %v", record.EatenAt().Time(), eatenAtTime)
+		}
+		if !record.CreatedAt().Equal(createdAt) {
+			t.Errorf("ReconstructRecord().CreatedAt() = %v, want %v", record.CreatedAt(), createdAt)
+		}
+		if len(record.Items()) != 2 {
+			t.Errorf("ReconstructRecord().Items() length = %d, want %d", len(record.Items()), 2)
+		}
+	})
 }
 
-func TestRecord_AddItem_異常系_無効なアイテム(t *testing.T) {
-	userID := vo.NewUserID()
-	eatenAt := time.Now().Add(-1 * time.Hour)
-
-	tests := []struct {
-		name     string
-		itemName string
-		calories int
-		wantErr  error
-	}{
-		{
-			name:     "食品名が空の場合",
-			itemName: "",
-			calories: 180,
-			wantErr:  domainErrors.ErrItemNameRequired,
-		},
-		{
-			name:     "カロリーが0以下の場合",
-			itemName: "おにぎり",
-			calories: 0,
-			wantErr:  domainErrors.ErrCaloriesMustBePositive,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			record, _ := entity.NewRecord(userID, eatenAt)
-			err := record.AddItem(tt.itemName, tt.calories)
-
-			if err != tt.wantErr {
-				t.Errorf("AddItem() error = %v, want %v", err, tt.wantErr)
-			}
-			if len(record.Items()) != 0 {
-				t.Errorf("AddItem() should not add item on error, items count = %d", len(record.Items()))
-			}
-		})
-	}
-}
-
-func TestReconstructRecord_DB復元(t *testing.T) {
-	idStr := "record-123"
-	userIDStr := "user-456"
-	eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
-	createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
-	items := []entity.RecordItem{
-		*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
-		*entity.ReconstructRecordItem("item-2", idStr, "味噌汁", 50),
-	}
-
-	record := entity.ReconstructRecord(idStr, userIDStr, eatenAtTime, createdAt, items)
-
-	if record.ID().String() != idStr {
-		t.Errorf("ReconstructRecord().ID() = %v, want %v", record.ID().String(), idStr)
-	}
-	if record.UserID().String() != userIDStr {
-		t.Errorf("ReconstructRecord().UserID() = %v, want %v", record.UserID().String(), userIDStr)
-	}
-	if !record.EatenAt().Time().Equal(eatenAtTime) {
-		t.Errorf("ReconstructRecord().EatenAt() = %v, want %v", record.EatenAt().Time(), eatenAtTime)
-	}
-	if !record.CreatedAt().Equal(createdAt) {
-		t.Errorf("ReconstructRecord().CreatedAt() = %v, want %v", record.CreatedAt(), createdAt)
-	}
-	if len(record.Items()) != 2 {
-		t.Errorf("ReconstructRecord().Items() length = %d, want %d", len(record.Items()), 2)
-	}
-}
-
-func TestRecord_TotalCalories_合計カロリー計算(t *testing.T) {
+func TestRecord_TotalCalories(t *testing.T) {
 	idStr := "record-123"
 	userIDStr := "user-456"
 	eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
@@ -180,24 +186,26 @@ func TestRecord_TotalCalories_合計カロリー計算(t *testing.T) {
 	}
 }
 
-func TestReconstructRecordItem_DB復元(t *testing.T) {
-	idStr := "item-123"
-	recordIDStr := "record-456"
-	nameStr := "おにぎり"
-	caloriesVal := 180
+func TestReconstructRecordItem(t *testing.T) {
+	t.Run("DB復元", func(t *testing.T) {
+		idStr := "item-123"
+		recordIDStr := "record-456"
+		nameStr := "おにぎり"
+		caloriesVal := 180
 
-	item := entity.ReconstructRecordItem(idStr, recordIDStr, nameStr, caloriesVal)
+		item := entity.ReconstructRecordItem(idStr, recordIDStr, nameStr, caloriesVal)
 
-	if item.ID().String() != idStr {
-		t.Errorf("ReconstructRecordItem().ID() = %v, want %v", item.ID().String(), idStr)
-	}
-	if item.RecordID().String() != recordIDStr {
-		t.Errorf("ReconstructRecordItem().RecordID() = %v, want %v", item.RecordID().String(), recordIDStr)
-	}
-	if item.Name().String() != nameStr {
-		t.Errorf("ReconstructRecordItem().Name() = %v, want %v", item.Name().String(), nameStr)
-	}
-	if item.Calories().Value() != caloriesVal {
-		t.Errorf("ReconstructRecordItem().Calories() = %v, want %v", item.Calories().Value(), caloriesVal)
-	}
+		if item.ID().String() != idStr {
+			t.Errorf("ReconstructRecordItem().ID() = %v, want %v", item.ID().String(), idStr)
+		}
+		if item.RecordID().String() != recordIDStr {
+			t.Errorf("ReconstructRecordItem().RecordID() = %v, want %v", item.RecordID().String(), recordIDStr)
+		}
+		if item.Name().String() != nameStr {
+			t.Errorf("ReconstructRecordItem().Name() = %v, want %v", item.Name().String(), nameStr)
+		}
+		if item.Calories().Value() != caloriesVal {
+			t.Errorf("ReconstructRecordItem().Calories() = %v, want %v", item.Calories().Value(), caloriesVal)
+		}
+	})
 }

--- a/backend/domain/vo/eaten_at_test.go
+++ b/backend/domain/vo/eaten_at_test.go
@@ -127,10 +127,12 @@ func TestEatenAt_MealType(t *testing.T) {
 	}
 }
 
-func TestMealType_String_不明な値(t *testing.T) {
-	// 定義されていないMealType値の場合
-	invalidType := MealType(99)
-	if got := invalidType.String(); got != "不明" {
-		t.Errorf("MealType(99).String() = %v, want %v", got, "不明")
-	}
+func TestMealType_String(t *testing.T) {
+	t.Run("不明な値", func(t *testing.T) {
+		// 定義されていないMealType値の場合
+		invalidType := MealType(99)
+		if got := invalidType.String(); got != "不明" {
+			t.Errorf("MealType(99).String() = %v, want %v", got, "不明")
+		}
+	})
 }

--- a/backend/handler/middleware/auth.go
+++ b/backend/handler/middleware/auth.go
@@ -1,0 +1,62 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/handler/common"
+	"caltrack/usecase"
+)
+
+// AuthMiddleware は認証ミドルウェアを生成する
+func AuthMiddleware(authUsecase *usecase.AuthUsecase) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// CookieからセッションIDを取得
+		sessionID, err := c.Cookie("session_id")
+		if err != nil {
+			common.RespondError(c, http.StatusUnauthorized, common.CodeUnauthorized, "Authentication required", nil)
+			c.Abort()
+			return
+		}
+
+		// セッションの有効性を検証
+		session, err := authUsecase.ValidateSession(c.Request.Context(), sessionID)
+		if err != nil {
+			handleAuthError(c, err)
+			c.Abort()
+			return
+		}
+
+		// コンテキストにユーザー情報を設定
+		c.Set("userID", session.UserID().String())
+		c.Set("sessionID", session.ID().String())
+		c.Next()
+	}
+}
+
+// handleAuthError は認証エラーをHTTPレスポンスに変換する
+func handleAuthError(c *gin.Context, err error) {
+	// 無効なセッションID
+	if errors.Is(err, domainErrors.ErrInvalidSessionID) {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeUnauthorized, "Invalid session", nil)
+		return
+	}
+
+	// セッションが見つからない
+	if errors.Is(err, domainErrors.ErrSessionNotFound) {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeUnauthorized, "Invalid session", nil)
+		return
+	}
+
+	// セッション期限切れ
+	if errors.Is(err, domainErrors.ErrSessionExpired) {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeSessionExpired, "Session has expired", nil)
+		return
+	}
+
+	// その他のエラー
+	common.RespondError(c, http.StatusInternalServerError, common.CodeInternalError, "Internal server error", err)
+}

--- a/backend/handler/middleware/auth_test.go
+++ b/backend/handler/middleware/auth_test.go
@@ -1,0 +1,320 @@
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+	"caltrack/handler/common"
+	"caltrack/handler/middleware"
+	"caltrack/usecase"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// mockUserRepository はUserRepositoryのモック実装
+type mockUserRepository struct {
+	existsByEmail func(ctx context.Context, email vo.Email) (bool, error)
+	save          func(ctx context.Context, user *entity.User) error
+	findByEmail   func(ctx context.Context, email vo.Email) (*entity.User, error)
+}
+
+func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
+	return m.existsByEmail(ctx, email)
+}
+
+func (m *mockUserRepository) Save(ctx context.Context, u *entity.User) error {
+	return m.save(ctx, u)
+}
+
+func (m *mockUserRepository) FindByEmail(ctx context.Context, email vo.Email) (*entity.User, error) {
+	return m.findByEmail(ctx, email)
+}
+
+// mockSessionRepository はSessionRepositoryのモック実装
+type mockSessionRepository struct {
+	save           func(ctx context.Context, session *entity.Session) error
+	findByID       func(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error)
+	deleteByID     func(ctx context.Context, sessionID vo.SessionID) error
+	deleteByUserID func(ctx context.Context, userID vo.UserID) error
+}
+
+func (m *mockSessionRepository) Save(ctx context.Context, session *entity.Session) error {
+	return m.save(ctx, session)
+}
+
+func (m *mockSessionRepository) FindByID(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error) {
+	return m.findByID(ctx, sessionID)
+}
+
+func (m *mockSessionRepository) DeleteByID(ctx context.Context, sessionID vo.SessionID) error {
+	return m.deleteByID(ctx, sessionID)
+}
+
+func (m *mockSessionRepository) DeleteByUserID(ctx context.Context, userID vo.UserID) error {
+	return m.deleteByUserID(ctx, userID)
+}
+
+// mockTransactionManager はTransactionManagerのモック実装
+type mockTransactionManager struct{}
+
+func (m *mockTransactionManager) Execute(ctx context.Context, fn func(ctx context.Context) error) error {
+	return fn(ctx)
+}
+
+// createTestSession はテスト用のセッションを作成する
+func createTestSession(t *testing.T, userIDStr string) *entity.Session {
+	t.Helper()
+	userID := vo.ReconstructUserID(userIDStr)
+	session, err := entity.NewSessionWithUserID(userID)
+	if err != nil {
+		t.Fatalf("failed to create test session: %v", err)
+	}
+	return session
+}
+
+func TestAuthMiddleware(t *testing.T) {
+	t.Run("正常系_認証成功", func(t *testing.T) {
+		testUserID := "550e8400-e29b-41d4-a716-446655440000"
+		testSession := createTestSession(t, testUserID)
+
+		userRepo := &mockUserRepository{}
+		sessionRepo := &mockSessionRepository{
+			findByID: func(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error) {
+				return testSession, nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+
+		// ミドルウェアを設定したルーターを作成
+		r := gin.New()
+		r.Use(middleware.AuthMiddleware(authUsecase))
+		r.GET("/protected", func(c *gin.Context) {
+			userID, _ := c.Get("userID")
+			c.JSON(http.StatusOK, gin.H{"userID": userID})
+		})
+
+		// リクエストを作成
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  "session_id",
+			Value: testSession.ID().String(),
+		})
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		var resp map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp["userID"] != testUserID {
+			t.Errorf("userID = %s, want %s", resp["userID"], testUserID)
+		}
+	})
+
+	t.Run("異常系_Cookieなし", func(t *testing.T) {
+		userRepo := &mockUserRepository{}
+		sessionRepo := &mockSessionRepository{}
+		txManager := &mockTransactionManager{}
+		authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+
+		r := gin.New()
+		r.Use(middleware.AuthMiddleware(authUsecase))
+		r.GET("/protected", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"message": "success"})
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		// Cookieを設定しない
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeUnauthorized {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeUnauthorized)
+		}
+	})
+
+	t.Run("異常系_無効なセッションID", func(t *testing.T) {
+		userRepo := &mockUserRepository{}
+		sessionRepo := &mockSessionRepository{}
+		txManager := &mockTransactionManager{}
+		authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+
+		r := gin.New()
+		r.Use(middleware.AuthMiddleware(authUsecase))
+		r.GET("/protected", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"message": "success"})
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		req.AddCookie(&http.Cookie{
+			Name:  "session_id",
+			Value: "invalid-session-id",
+		})
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeUnauthorized {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeUnauthorized)
+		}
+	})
+
+	t.Run("異常系_セッションが見つからない", func(t *testing.T) {
+		userRepo := &mockUserRepository{}
+		sessionRepo := &mockSessionRepository{
+			findByID: func(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error) {
+				return nil, nil // セッションが見つからない
+			},
+		}
+		txManager := &mockTransactionManager{}
+		authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+
+		r := gin.New()
+		r.Use(middleware.AuthMiddleware(authUsecase))
+		r.GET("/protected", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"message": "success"})
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		// 有効なセッションID形式
+		validSessionID := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+		req.AddCookie(&http.Cookie{
+			Name:  "session_id",
+			Value: validSessionID,
+		})
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("異常系_セッション期限切れ", func(t *testing.T) {
+		userRepo := &mockUserRepository{}
+		sessionRepo := &mockSessionRepository{
+			findByID: func(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error) {
+				// 期限切れセッションを返す
+				expiredSession, err := entity.ReconstructSession(
+					sessionID.String(),
+					"550e8400-e29b-41d4-a716-446655440000",
+					time.Now().Add(-24*time.Hour), // 過去の時刻（期限切れ）
+					time.Now().Add(-48*time.Hour), // 作成日時
+				)
+				if err != nil {
+					return nil, err
+				}
+				return expiredSession, nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+
+		r := gin.New()
+		r.Use(middleware.AuthMiddleware(authUsecase))
+		r.GET("/protected", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"message": "success"})
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		validSessionID := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+		req.AddCookie(&http.Cookie{
+			Name:  "session_id",
+			Value: validSessionID,
+		})
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeSessionExpired {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeSessionExpired)
+		}
+	})
+
+	t.Run("異常系_内部エラー", func(t *testing.T) {
+		userRepo := &mockUserRepository{}
+		sessionRepo := &mockSessionRepository{
+			findByID: func(ctx context.Context, sessionID vo.SessionID) (*entity.Session, error) {
+				return nil, domainErrors.ErrSessionIDGenerationFailed
+			},
+		}
+		txManager := &mockTransactionManager{}
+		authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
+
+		r := gin.New()
+		r.Use(middleware.AuthMiddleware(authUsecase))
+		r.GET("/protected", func(c *gin.Context) {
+			c.JSON(http.StatusOK, gin.H{"message": "success"})
+		})
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+		validSessionID := "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+		req.AddCookie(&http.Cookie{
+			Name:  "session_id",
+			Value: validSessionID,
+		})
+
+		r.ServeHTTP(w, req)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeInternalError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeInternalError)
+		}
+	})
+}

--- a/backend/handler/record/dto/request.go
+++ b/backend/handler/record/dto/request.go
@@ -1,0 +1,52 @@
+package dto
+
+import (
+	"time"
+
+	"caltrack/domain/entity"
+	"caltrack/domain/vo"
+)
+
+// CreateRecordRequest はカロリー記録作成リクエストDTO
+type CreateRecordRequest struct {
+	EatenAt string              `json:"eatenAt"`
+	Items   []RecordItemRequest `json:"items"`
+}
+
+// RecordItemRequest は記録明細リクエストDTO
+type RecordItemRequest struct {
+	Name     string `json:"name"`
+	Calories int    `json:"calories"`
+}
+
+// ToDomain はリクエストをEntityに変換する
+func (r CreateRecordRequest) ToDomain(userIDStr string) (*entity.Record, error, []error) {
+	// UserIDの復元
+	userID := vo.ReconstructUserID(userIDStr)
+
+	// 日時のパース
+	eatenAtTime, parseErr := time.Parse(time.RFC3339, r.EatenAt)
+	if parseErr != nil {
+		return nil, parseErr, nil
+	}
+
+	// Record作成
+	record, err := entity.NewRecord(userID, eatenAtTime)
+	if err != nil {
+		return nil, nil, []error{err}
+	}
+
+	// Items追加
+	var validationErrs []error
+	for _, item := range r.Items {
+		if err := record.AddItem(item.Name, item.Calories); err != nil {
+			validationErrs = append(validationErrs, err)
+		}
+	}
+
+	if len(validationErrs) > 0 {
+		return nil, nil, validationErrs
+	}
+
+	return record, nil, nil
+}

--- a/backend/handler/record/dto/response.go
+++ b/backend/handler/record/dto/response.go
@@ -1,0 +1,41 @@
+package dto
+
+import (
+	"time"
+
+	"caltrack/domain/entity"
+)
+
+// CreateRecordResponse はカロリー記録作成レスポンスDTO
+type CreateRecordResponse struct {
+	RecordID      string               `json:"recordId"`
+	EatenAt       string               `json:"eatenAt"`
+	TotalCalories int                  `json:"totalCalories"`
+	Items         []RecordItemResponse `json:"items"`
+}
+
+// RecordItemResponse は記録明細レスポンスDTO
+type RecordItemResponse struct {
+	ItemID   string `json:"itemId"`
+	Name     string `json:"name"`
+	Calories int    `json:"calories"`
+}
+
+// NewCreateRecordResponse はEntityからレスポンスDTOを生成する
+func NewCreateRecordResponse(record *entity.Record) CreateRecordResponse {
+	items := make([]RecordItemResponse, len(record.Items()))
+	for i, item := range record.Items() {
+		items[i] = RecordItemResponse{
+			ItemID:   item.ID().String(),
+			Name:     item.Name().String(),
+			Calories: item.Calories().Value(),
+		}
+	}
+
+	return CreateRecordResponse{
+		RecordID:      record.ID().String(),
+		EatenAt:       record.EatenAt().Time().Format(time.RFC3339),
+		TotalCalories: record.TotalCalories(),
+		Items:         items,
+	}
+}

--- a/backend/handler/record/handler_test.go
+++ b/backend/handler/record/handler_test.go
@@ -1,0 +1,353 @@
+package record_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"caltrack/domain/entity"
+	"caltrack/domain/repository"
+	"caltrack/handler/common"
+	"caltrack/handler/record"
+	"caltrack/handler/record/dto"
+	"caltrack/usecase"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// mockRecordRepository はRecordRepositoryのモック実装
+type mockRecordRepository struct {
+	save func(ctx context.Context, record *entity.Record) error
+}
+
+func (m *mockRecordRepository) Save(ctx context.Context, record *entity.Record) error {
+	return m.save(ctx, record)
+}
+
+// mockTransactionManager はTransactionManagerのモック実装
+type mockTransactionManager struct{}
+
+func (m *mockTransactionManager) Execute(ctx context.Context, fn func(ctx context.Context) error) error {
+	return fn(ctx)
+}
+
+// setupHandler はテスト用のハンドラをセットアップする
+func setupHandler(recordRepo repository.RecordRepository) *record.RecordHandler {
+	txManager := &mockTransactionManager{}
+	uc := usecase.NewRecordUsecase(recordRepo, txManager)
+	return record.NewRecordHandler(uc)
+}
+
+func TestRecordHandler_Create(t *testing.T) {
+	t.Run("正常系_記録が作成される", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{
+			save: func(ctx context.Context, record *entity.Record) error {
+				return nil
+			},
+		}
+		handler := setupHandler(recordRepo)
+
+		// 現在時刻から少し前の日時を使用（未来日時エラーを回避）
+		eatenAt := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+		reqBody := `{
+		"eatenAt": "` + eatenAt + `",
+		"items": [
+			{"name": "ご飯", "calories": 250},
+			{"name": "味噌汁", "calories": 50}
+		]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusCreated {
+			t.Errorf("status = %d, want %d, body = %s", w.Code, http.StatusCreated, w.Body.String())
+		}
+
+		// レスポンスボディの検証
+		var resp dto.CreateRecordResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.RecordID == "" {
+			t.Error("recordId should not be empty")
+		}
+		if resp.TotalCalories != 300 {
+			t.Errorf("totalCalories = %d, want %d", resp.TotalCalories, 300)
+		}
+		if len(resp.Items) != 2 {
+			t.Errorf("items count = %d, want %d", len(resp.Items), 2)
+		}
+	})
+
+	t.Run("異常系_認証なし", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		reqBody := `{
+		"eatenAt": "2024-01-15T12:00:00Z",
+		"items": [{"name": "ご飯", "calories": 250}]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		// userIDを設定しない
+
+		handler.Create(c)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeUnauthorized {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeUnauthorized)
+		}
+	})
+
+	t.Run("異常系_無効なリクエストボディ", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		reqBody := `{invalid json}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeInvalidRequest {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeInvalidRequest)
+		}
+	})
+
+	t.Run("異常系_明細が空", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		reqBody := `{
+		"eatenAt": "2024-01-15T12:00:00Z",
+		"items": []
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeValidationError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeValidationError)
+		}
+		if len(resp.Details) == 0 {
+			t.Error("details should not be empty")
+		}
+	})
+
+	t.Run("異常系_無効なeatenAt形式", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		reqBody := `{
+		"eatenAt": "invalid-date-format",
+		"items": [{"name": "ご飯", "calories": 250}]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeValidationError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeValidationError)
+		}
+	})
+
+	t.Run("異常系_未来日時エラー", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		// 1年後の日時を設定
+		futureTime := time.Now().AddDate(1, 0, 0).Format(time.RFC3339)
+		reqBody := `{
+		"eatenAt": "` + futureTime + `",
+		"items": [{"name": "ご飯", "calories": 250}]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeValidationError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeValidationError)
+		}
+	})
+
+	t.Run("異常系_カロリーが負の値", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		eatenAt := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+		reqBody := `{
+		"eatenAt": "` + eatenAt + `",
+		"items": [{"name": "ご飯", "calories": -100}]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeValidationError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeValidationError)
+		}
+	})
+
+	t.Run("異常系_食品名が空", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{}
+		handler := setupHandler(recordRepo)
+
+		eatenAt := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+		reqBody := `{
+		"eatenAt": "` + eatenAt + `",
+		"items": [{"name": "", "calories": 250}]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeValidationError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeValidationError)
+		}
+	})
+
+	t.Run("異常系_DB保存失敗", func(t *testing.T) {
+		recordRepo := &mockRecordRepository{
+			save: func(ctx context.Context, record *entity.Record) error {
+				return context.DeadlineExceeded
+			},
+		}
+		handler := setupHandler(recordRepo)
+
+		eatenAt := time.Now().Add(-1 * time.Hour).Format(time.RFC3339)
+		reqBody := `{
+		"eatenAt": "` + eatenAt + `",
+		"items": [{"name": "ご飯", "calories": 250}]
+	}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/records", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", "550e8400-e29b-41d4-a716-446655440000")
+
+		handler.Create(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeInternalError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeInternalError)
+		}
+	})
+}

--- a/backend/handler/user/handler_test.go
+++ b/backend/handler/user/handler_test.go
@@ -42,139 +42,141 @@ func (m *mockTransactionManager) Execute(ctx context.Context, fn func(ctx contex
 	return fn(ctx)
 }
 
-func TestUserHandler_Register_Success(t *testing.T) {
-	repo := &mockUserRepository{
-		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
-			return false, nil
-		},
-		save: func(ctx context.Context, u *entity.User) error {
-			return nil
-		},
-	}
-	txManager := &mockTransactionManager{}
-	uc := usecase.NewUserUsecase(repo, txManager)
-	handler := user.NewUserHandler(uc)
+func TestUserHandler_Register(t *testing.T) {
+	t.Run("正常系_登録成功", func(t *testing.T) {
+		repo := &mockUserRepository{
+			existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+				return false, nil
+			},
+			save: func(ctx context.Context, u *entity.User) error {
+				return nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
 
-	reqBody := `{
-		"email": "test@example.com",
-		"password": "password123",
-		"nickname": "testuser",
-		"weight": 70.5,
-		"height": 175.0,
-		"birthDate": "1990-01-01",
-		"gender": "male",
-		"activityLevel": "moderate"
-	}`
+		reqBody := `{
+			"email": "test@example.com",
+			"password": "password123",
+			"nickname": "testuser",
+			"weight": 70.5,
+			"height": 175.0,
+			"birthDate": "1990-01-01",
+			"gender": "male",
+			"activityLevel": "moderate"
+		}`
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
-	c.Request.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
 
-	handler.Register(c)
+		handler.Register(c)
 
-	if w.Code != http.StatusCreated {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusCreated)
-	}
-}
+		if w.Code != http.StatusCreated {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusCreated)
+		}
+	})
 
-func TestUserHandler_Register_EmailAlreadyExists(t *testing.T) {
-	repo := &mockUserRepository{
-		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
-			return true, nil
-		},
-		save: func(ctx context.Context, u *entity.User) error {
-			return nil
-		},
-	}
-	txManager := &mockTransactionManager{}
-	uc := usecase.NewUserUsecase(repo, txManager)
-	handler := user.NewUserHandler(uc)
+	t.Run("異常系_メールアドレス重複", func(t *testing.T) {
+		repo := &mockUserRepository{
+			existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+				return true, nil
+			},
+			save: func(ctx context.Context, u *entity.User) error {
+				return nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
 
-	reqBody := `{
-		"email": "test@example.com",
-		"password": "password123",
-		"nickname": "testuser",
-		"weight": 70.5,
-		"height": 175.0,
-		"birthDate": "1990-01-01",
-		"gender": "male",
-		"activityLevel": "moderate"
-	}`
+		reqBody := `{
+			"email": "test@example.com",
+			"password": "password123",
+			"nickname": "testuser",
+			"weight": 70.5,
+			"height": 175.0,
+			"birthDate": "1990-01-01",
+			"gender": "male",
+			"activityLevel": "moderate"
+		}`
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
-	c.Request.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
 
-	handler.Register(c)
+		handler.Register(c)
 
-	if w.Code != http.StatusConflict {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
-	}
-}
+		if w.Code != http.StatusConflict {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusConflict)
+		}
+	})
 
-func TestUserHandler_Register_ValidationError(t *testing.T) {
-	repo := &mockUserRepository{
-		existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
-			return false, nil
-		},
-		save: func(ctx context.Context, u *entity.User) error {
-			return nil
-		},
-	}
-	txManager := &mockTransactionManager{}
-	uc := usecase.NewUserUsecase(repo, txManager)
-	handler := user.NewUserHandler(uc)
+	t.Run("異常系_バリデーションエラー", func(t *testing.T) {
+		repo := &mockUserRepository{
+			existsByEmail: func(ctx context.Context, email vo.Email) (bool, error) {
+				return false, nil
+			},
+			save: func(ctx context.Context, u *entity.User) error {
+				return nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
 
-	reqBody := `{
-		"email": "invalid-email",
-		"password": "password123",
-		"nickname": "testuser",
-		"weight": 70.5,
-		"height": 175.0,
-		"birthDate": "1990-01-01",
-		"gender": "male",
-		"activityLevel": "moderate"
-	}`
+		reqBody := `{
+			"email": "invalid-email",
+			"password": "password123",
+			"nickname": "testuser",
+			"weight": 70.5,
+			"height": 175.0,
+			"birthDate": "1990-01-01",
+			"gender": "male",
+			"activityLevel": "moderate"
+		}`
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
-	c.Request.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
 
-	handler.Register(c)
+		handler.Register(c)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
-	}
-}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
 
-func TestUserHandler_Register_InvalidBirthDateFormat(t *testing.T) {
-	repo := &mockUserRepository{}
-	txManager := &mockTransactionManager{}
-	uc := usecase.NewUserUsecase(repo, txManager)
-	handler := user.NewUserHandler(uc)
+	t.Run("異常系_不正な生年月日フォーマット", func(t *testing.T) {
+		repo := &mockUserRepository{}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
 
-	reqBody := `{
-		"email": "test@example.com",
-		"password": "password123",
-		"nickname": "testuser",
-		"weight": 70.5,
-		"height": 175.0,
-		"birthDate": "invalid-date",
-		"gender": "male",
-		"activityLevel": "moderate"
-	}`
+		reqBody := `{
+			"email": "test@example.com",
+			"password": "password123",
+			"nickname": "testuser",
+			"weight": 70.5,
+			"height": 175.0,
+			"birthDate": "invalid-date",
+			"gender": "male",
+			"activityLevel": "moderate"
+		}`
 
-	w := httptest.NewRecorder()
-	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
-	c.Request.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/users", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
 
-	handler.Register(c)
+		handler.Register(c)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
-	}
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
 }

--- a/backend/usecase/record_test.go
+++ b/backend/usecase/record_test.go
@@ -38,44 +38,46 @@ func validRecord(t *testing.T) *entity.Record {
 	return record
 }
 
-func TestRecordUsecase_Create_正常系_記録が保存される(t *testing.T) {
-	var savedRecord *entity.Record
-	repo := &mockRecordRepository{
-		save: func(ctx context.Context, record *entity.Record) error {
-			savedRecord = record
-			return nil
-		},
-	}
-	txManager := &mockRecordTransactionManager{}
+func TestRecordUsecase_Create(t *testing.T) {
+	t.Run("正常系_記録が保存される", func(t *testing.T) {
+		var savedRecord *entity.Record
+		repo := &mockRecordRepository{
+			save: func(ctx context.Context, record *entity.Record) error {
+				savedRecord = record
+				return nil
+			},
+		}
+		txManager := &mockRecordTransactionManager{}
 
-	uc := usecase.NewRecordUsecase(repo, txManager)
-	record := validRecord(t)
-	err := uc.Create(context.Background(), record)
+		uc := usecase.NewRecordUsecase(repo, txManager)
+		record := validRecord(t)
+		err := uc.Create(context.Background(), record)
 
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if savedRecord == nil {
-		t.Error("record should be saved")
-	}
-	if savedRecord.ID().String() != record.ID().String() {
-		t.Errorf("saved record ID = %s, want %s", savedRecord.ID().String(), record.ID().String())
-	}
-}
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if savedRecord == nil {
+			t.Error("record should be saved")
+		}
+		if savedRecord.ID().String() != record.ID().String() {
+			t.Errorf("saved record ID = %s, want %s", savedRecord.ID().String(), record.ID().String())
+		}
+	})
 
-func TestRecordUsecase_Create_異常系_保存時にエラーが発生(t *testing.T) {
-	saveErr := errors.New("save error")
-	repo := &mockRecordRepository{
-		save: func(ctx context.Context, record *entity.Record) error {
-			return saveErr
-		},
-	}
-	txManager := &mockRecordTransactionManager{}
+	t.Run("異常系_保存時にエラーが発生", func(t *testing.T) {
+		saveErr := errors.New("save error")
+		repo := &mockRecordRepository{
+			save: func(ctx context.Context, record *entity.Record) error {
+				return saveErr
+			},
+		}
+		txManager := &mockRecordTransactionManager{}
 
-	uc := usecase.NewRecordUsecase(repo, txManager)
-	err := uc.Create(context.Background(), validRecord(t))
+		uc := usecase.NewRecordUsecase(repo, txManager)
+		err := uc.Create(context.Background(), validRecord(t))
 
-	if !errors.Is(err, saveErr) {
-		t.Errorf("got %v, want saveErr", err)
-	}
+		if !errors.Is(err, saveErr) {
+			t.Errorf("got %v, want saveErr", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- RecordHandler実装（POST /api/records）
- 認証ミドルウェア実装（セッション検証、UserID取得）
- リクエスト/レスポンスDTO定義
- main.goにDI・ルーティング追加
- 全テストファイルをt.Run形式に統一（命名規則修正）

## Test plan
- [x] Build: Pass
- [x] Test: Pass (274 tests)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)