### PR TITLE
feat(auth): LogoutButton StoryとHeaderへの組み込み

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,15 +1,19 @@
 /**
  * Header - 共通ヘッダーコンポーネント
  */
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { LogoutButton } from "@/features/auth";
 
 export function Header() {
+  const navigate = useNavigate();
+
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur">
       <div className="container flex h-14 items-center justify-between px-4 mx-auto max-w-4xl">
         <Link to="/dashboard" className="flex items-center gap-2">
           <span className="text-xl font-bold text-primary">CalTrack</span>
         </Link>
+        <LogoutButton onSuccess={() => navigate("/")} />
       </div>
     </header>
   );

--- a/frontend/src/features/auth/components/LogoutButton.stories.tsx
+++ b/frontend/src/features/auth/components/LogoutButton.stories.tsx
@@ -1,0 +1,30 @@
+/**
+ * LogoutButton コンポーネントのStorybook
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LogoutButton } from "./LogoutButton";
+
+const meta: Meta<typeof LogoutButton> = {
+  title: "Features/Auth/LogoutButton",
+  component: LogoutButton,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LogoutButton>;
+
+/** デフォルト状態 */
+export const Default: Story = {};
+
+/** 成功コールバック付き */
+export const WithOnSuccess: Story = {
+  args: {
+    onSuccess: () => {
+      console.log("ログアウト成功");
+      alert("ログアウトしました！");
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- LogoutButton用Storybookファイルを追加
- HeaderコンポーネントにLogoutButtonを組み込み
- ログアウト成功時にトップページへ遷移する機能を実装

## Test plan
- [x] Build: Pass
- [x] Storybook: LogoutButton Story表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)