### PR TITLE
feat(handler): GET /records/today エンドポイント追加

### DIFF
--- a/backend/handler/common/error_code.go
+++ b/backend/handler/common/error_code.go
@@ -5,6 +5,7 @@ const (
 	CodeValidationError    = "VALIDATION_ERROR"
 	CodeEmailAlreadyExists = "EMAIL_ALREADY_EXISTS"
 	CodeInternalError      = "INTERNAL_ERROR"
+	CodeNotFound           = "NOT_FOUND"
 
 	// 認証関連エラーコード
 	CodeInvalidCredentials = "INVALID_CREDENTIALS"

--- a/backend/handler/record/dto/response.go
+++ b/backend/handler/record/dto/response.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"caltrack/domain/entity"
+	"caltrack/usecase"
 )
 
 // CreateRecordResponse はカロリー記録作成レスポンスDTO
@@ -37,5 +38,49 @@ func NewCreateRecordResponse(record *entity.Record) CreateRecordResponse {
 		EatenAt:       record.EatenAt().Time().Format(time.RFC3339),
 		TotalCalories: record.TotalCalories(),
 		Items:         items,
+	}
+}
+
+// TodayCaloriesResponse は今日の摂取カロリーレスポンスDTO
+type TodayCaloriesResponse struct {
+	Date           string           `json:"date"`
+	TotalCalories  int              `json:"totalCalories"`
+	TargetCalories int              `json:"targetCalories"`
+	Difference     int              `json:"difference"`
+	Records        []RecordResponse `json:"records"`
+}
+
+// RecordResponse は記録レスポンスDTO
+type RecordResponse struct {
+	ID      string               `json:"id"`
+	EatenAt string               `json:"eatenAt"`
+	Items   []RecordItemResponse `json:"items"`
+}
+
+// NewTodayCaloriesResponse はUsecaseの出力からレスポンスDTOを生成する
+func NewTodayCaloriesResponse(output *usecase.TodayCaloriesOutput) TodayCaloriesResponse {
+	records := make([]RecordResponse, len(output.Records))
+	for i, record := range output.Records {
+		items := make([]RecordItemResponse, len(record.Items()))
+		for j, item := range record.Items() {
+			items[j] = RecordItemResponse{
+				ItemID:   item.ID().String(),
+				Name:     item.Name().String(),
+				Calories: item.Calories().Value(),
+			}
+		}
+		records[i] = RecordResponse{
+			ID:      record.ID().String(),
+			EatenAt: record.EatenAt().Time().Format(time.RFC3339),
+			Items:   items,
+		}
+	}
+
+	return TodayCaloriesResponse{
+		Date:           output.Date.Format("2006-01-02"),
+		TotalCalories:  output.TotalCalories,
+		TargetCalories: output.TargetCalories,
+		Difference:     output.Difference,
+		Records:        records,
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -91,6 +91,7 @@ func main() {
 	authenticated.Use(middleware.AuthMiddleware(authUsecase))
 	{
 		authenticated.POST("/records", recordHandler.Create)
+		authenticated.GET("/records/today", recordHandler.GetToday)
 	}
 
 	// Start server


### PR DESCRIPTION
## Summary
- TodayCaloriesResponse DTOを追加
- GetTodayハンドラを実装（認証ユーザーの今日の摂取カロリー情報を取得）
- CodeNotFoundエラーコードを追加
- GET /records/today ルートを追加
- GetTodayテストを追加（6テストケース）

## Test plan
- [x] Build: Pass
- [x] Test: Pass (6 tests for GetToday)

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)