### PR TITLE
feat(frontend): 記録一覧とmealTypeラベル表示

### DIFF
--- a/frontend/src/domain/valueObjects/eatenAt.ts
+++ b/frontend/src/domain/valueObjects/eatenAt.ts
@@ -21,6 +21,8 @@ export const MEAL_TYPE_LABELS: Record<MealType, string> = {
 export type EatenAt = Readonly<{
   value: Date;
   mealType: () => MealType;
+  mealTypeLabel: () => string;
+  formattedTime: () => string;
   equals: (other: EatenAt) => boolean;
   toDateTimeLocal: () => string;
   toISOString: () => string;
@@ -73,23 +75,24 @@ export const newEatenAt = (
     return err(domainError("EATEN_AT_MUST_NOT_BE_FUTURE", ERROR_MESSAGES.EATEN_AT_MUST_NOT_BE_FUTURE));
   }
 
+  const mealType = determineMealType(date);
+
   const eatenAt: EatenAt = Object.freeze({
     value: date,
-    mealType: () => determineMealType(date),
+    mealType: () => mealType,
+    mealTypeLabel: () => MEAL_TYPE_LABELS[mealType],
+    formattedTime: () =>
+      date.toLocaleTimeString("ja-JP", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+      }),
     equals: (other: EatenAt) => date.getTime() === other.value.getTime(),
-    /**
-     * datetime-local形式の文字列を返す
-     * @returns YYYY-MM-DDTHH:mm 形式
-     */
     toDateTimeLocal: () => {
       const offset = date.getTimezoneOffset();
       const localDate = new Date(date.getTime() - offset * 60 * 1000);
       return localDate.toISOString().slice(0, 16);
     },
-    /**
-     * ISO 8601形式の文字列を返す
-     * @returns ISO 8601形式
-     */
     toISOString: () => date.toISOString(),
   });
 

--- a/frontend/src/features/records/components/TodaySummary.stories.tsx
+++ b/frontend/src/features/records/components/TodaySummary.stories.tsx
@@ -1,0 +1,149 @@
+/**
+ * TodaySummary - Storybookストーリー
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TodaySummary } from "./TodaySummary";
+import type { TodayRecordsResponse } from "../hooks/useTodayRecords";
+import type { ApiErrorResponse } from "@/lib/api";
+
+const meta: Meta<typeof TodaySummary> = {
+  title: "Features/Records/TodaySummary",
+  component: TodaySummary,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TodaySummary>;
+
+/** モックデータ: 記録あり */
+const mockDataWithRecords: TodayRecordsResponse = {
+  date: "2024-01-15",
+  totalCalories: 1200,
+  targetCalories: 2000,
+  difference: -800,
+  records: [
+    {
+      id: "record-1",
+      eatenAt: "2024-01-15T08:30:00Z",
+      items: [
+        { itemId: "item-1", name: "トースト", calories: 200 },
+        { itemId: "item-2", name: "目玉焼き", calories: 150 },
+      ],
+    },
+    {
+      id: "record-2",
+      eatenAt: "2024-01-15T12:00:00Z",
+      items: [
+        { itemId: "item-3", name: "チキンカレー", calories: 650 },
+        { itemId: "item-4", name: "サラダ", calories: 50 },
+      ],
+    },
+    {
+      id: "record-3",
+      eatenAt: "2024-01-15T15:30:00Z",
+      items: [{ itemId: "item-5", name: "プロテインバー", calories: 150 }],
+    },
+  ],
+};
+
+/** モックデータ: 記録なし */
+const mockDataEmpty: TodayRecordsResponse = {
+  date: "2024-01-15",
+  totalCalories: 0,
+  targetCalories: 2000,
+  difference: -2000,
+  records: [],
+};
+
+/** モックデータ: 目標超過 */
+const mockDataOverTarget: TodayRecordsResponse = {
+  date: "2024-01-15",
+  totalCalories: 2500,
+  targetCalories: 2000,
+  difference: 500,
+  records: [
+    {
+      id: "record-1",
+      eatenAt: "2024-01-15T08:00:00Z",
+      items: [
+        { itemId: "item-1", name: "モーニングセット", calories: 600 },
+      ],
+    },
+    {
+      id: "record-2",
+      eatenAt: "2024-01-15T12:00:00Z",
+      items: [
+        { itemId: "item-2", name: "ラーメン大盛り", calories: 900 },
+        { itemId: "item-3", name: "餃子", calories: 300 },
+      ],
+    },
+    {
+      id: "record-3",
+      eatenAt: "2024-01-15T19:00:00Z",
+      items: [
+        { itemId: "item-4", name: "焼肉定食", calories: 700 },
+      ],
+    },
+  ],
+};
+
+/** モックエラー */
+const mockError: ApiErrorResponse = {
+  code: "INTERNAL_ERROR",
+  message: "サーバーエラーが発生しました",
+};
+
+/** デフォルト表示（記録あり） */
+export const Default: Story = {
+  args: {
+    data: mockDataWithRecords,
+    isPending: false,
+    error: null,
+  },
+};
+
+/** ローディング状態 */
+export const Loading: Story = {
+  args: {
+    data: null,
+    isPending: true,
+    error: null,
+  },
+};
+
+/** エラー状態 */
+export const Error: Story = {
+  args: {
+    data: null,
+    isPending: false,
+    error: mockError,
+  },
+};
+
+/** 記録が0件 */
+export const Empty: Story = {
+  args: {
+    data: mockDataEmpty,
+    isPending: false,
+    error: null,
+  },
+};
+
+/** 目標超過状態 */
+export const OverTarget: Story = {
+  args: {
+    data: mockDataOverTarget,
+    isPending: false,
+    error: null,
+  },
+};

--- a/frontend/src/features/records/components/TodaySummary.test.tsx
+++ b/frontend/src/features/records/components/TodaySummary.test.tsx
@@ -43,7 +43,7 @@ describe("TodaySummary", () => {
   describe("エラー状態", () => {
     it("エラー時にエラーメッセージが表示される", () => {
       const mockError: ApiErrorResponse = {
-        code: "SERVER_ERROR",
+        code: "INTERNAL_ERROR",
         message: "Internal Server Error",
       };
 

--- a/frontend/src/features/records/components/TodaySummary.tsx
+++ b/frontend/src/features/records/components/TodaySummary.tsx
@@ -1,11 +1,12 @@
 /**
  * TodaySummary - 今日のカロリーサマリーコンポーネント
- * 目標・摂取・残りカロリーを表示する
+ * 目標・摂取・残りカロリーと記録一覧を表示する
  */
-import { Card, CardContent } from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ApiErrorResponse } from "@/lib/api";
 import type { TodayRecordsResponse } from "../hooks/useTodayRecords";
+import { newEatenAt } from "@/domain/valueObjects/eatenAt";
 
 export type TodaySummaryProps = {
   data: TodayRecordsResponse | null;
@@ -20,15 +21,26 @@ export function TodaySummary({ data, isPending, error }: TodaySummaryProps) {
   // ローディング状態
   if (isPending && !data) {
     return (
-      <div className="grid gap-4 md:grid-cols-3">
-        {[...Array(3)].map((_, i) => (
-          <Card key={i}>
-            <CardContent className="pt-6">
-              <Skeleton className="h-4 w-20 mb-2" />
-              <Skeleton className="h-10 w-32" />
-            </CardContent>
-          </Card>
-        ))}
+      <div className="space-y-6">
+        <div className="grid gap-4 md:grid-cols-3">
+          {[...Array(3)].map((_, i) => (
+            <Card key={i}>
+              <CardContent className="pt-6">
+                <Skeleton className="h-4 w-20 mb-2" />
+                <Skeleton className="h-10 w-32" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-6 w-24" />
+          </CardHeader>
+          <CardContent>
+            <Skeleton className="h-4 w-full mb-2" />
+            <Skeleton className="h-4 w-3/4" />
+          </CardContent>
+        </Card>
       </div>
     );
   }
@@ -53,37 +65,102 @@ export function TodaySummary({ data, isPending, error }: TodaySummaryProps) {
   const isOverTarget = remainingCalories < 0;
 
   return (
-    <div className="grid gap-4 md:grid-cols-3">
-      {/* 目標カロリー */}
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-sm text-muted-foreground">目標</p>
-          <p className="text-3xl font-bold">
-            {data.targetCalories.toLocaleString()}
-            <span className="text-base font-normal text-muted-foreground ml-1">kcal</span>
-          </p>
-        </CardContent>
-      </Card>
+    <div className="space-y-6">
+      {/* サマリーカード */}
+      <div className="grid gap-4 md:grid-cols-3">
+        {/* 目標カロリー */}
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">目標</p>
+            <p className="text-3xl font-bold">
+              {data.targetCalories.toLocaleString()}
+              <span className="text-base font-normal text-muted-foreground ml-1">
+                kcal
+              </span>
+            </p>
+          </CardContent>
+        </Card>
 
-      {/* 摂取カロリー */}
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-sm text-muted-foreground">摂取</p>
-          <p className="text-3xl font-bold text-primary">
-            {data.totalCalories.toLocaleString()}
-            <span className="text-base font-normal text-muted-foreground ml-1">kcal</span>
-          </p>
-        </CardContent>
-      </Card>
+        {/* 摂取カロリー */}
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">摂取</p>
+            <p className="text-3xl font-bold text-primary">
+              {data.totalCalories.toLocaleString()}
+              <span className="text-base font-normal text-muted-foreground ml-1">
+                kcal
+              </span>
+            </p>
+          </CardContent>
+        </Card>
 
-      {/* 残り/超過カロリー */}
+        {/* 残り/超過カロリー */}
+        <Card>
+          <CardContent className="pt-6">
+            <p className="text-sm text-muted-foreground">
+              {isOverTarget ? "超過" : "残り"}
+            </p>
+            <p
+              className={`text-3xl font-bold ${isOverTarget ? "text-destructive" : "text-green-600"}`}
+            >
+              {Math.abs(remainingCalories).toLocaleString()}
+              <span className="text-base font-normal text-muted-foreground ml-1">
+                kcal
+              </span>
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 記録一覧 */}
       <Card>
-        <CardContent className="pt-6">
-          <p className="text-sm text-muted-foreground">{isOverTarget ? "超過" : "残り"}</p>
-          <p className={`text-3xl font-bold ${isOverTarget ? "text-destructive" : "text-green-600"}`}>
-            {Math.abs(remainingCalories).toLocaleString()}
-            <span className="text-base font-normal text-muted-foreground ml-1">kcal</span>
-          </p>
+        <CardHeader></CardHeader>
+        <CardContent>
+          {data.records.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              まだ記録がありません
+            </p>
+          ) : (
+            <div className="space-y-4">
+              {data.records.map((record) => {
+                const eatenAtResult = newEatenAt(record.eatenAt);
+                if (!eatenAtResult.ok) return null;
+                const eatenAt = eatenAtResult.value;
+
+                return (
+                  <div
+                    key={record.id}
+                    className="border-b last:border-b-0 pb-4 last:pb-0"
+                  >
+                    <p className="text-sm font-medium text-muted-foreground mb-2">
+                      {eatenAt.formattedTime()}
+                      <span className="ml-2 text-xs bg-muted px-2 py-0.5 rounded">
+                        {eatenAt.mealTypeLabel()}
+                      </span>
+                    </p>
+                    <ul className="space-y-1">
+                      {record.items.map((item, index) => (
+                        <li
+                          key={item.itemId}
+                          className="flex justify-between items-center text-sm"
+                        >
+                          <span className="flex items-center">
+                            <span className="text-muted-foreground mr-2">
+                              {index === record.items.length - 1 ? "└" : "├"}
+                            </span>
+                            {item.name}
+                          </span>
+                          <span className="text-muted-foreground">
+                            {item.calories.toLocaleString()} kcal
+                          </span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- EatenAt VOにformattedTime(), mealTypeLabel()メソッド追加
- TodaySummaryに記録一覧セクション追加（食事タイプ別表示）
- 日本語のmealTypeラベル表示対応
- Storybookによるコンポーネントカタログ追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)