### PR TITLE
feat: ダッシュボードUIの改善

### DIFF
--- a/backend/usecase/record.go
+++ b/backend/usecase/record.go
@@ -15,7 +15,7 @@ type TodayCaloriesOutput struct {
 	Date           time.Time        // 対象日付
 	TotalCalories  int              // 今日の合計カロリー
 	TargetCalories int              // 目標カロリー
-	Difference     int              // 差分（実績 - 目標）
+	Difference     int              // 差分（目標 - 実績）：プラスは残り、マイナスは超過
 	Records        []*entity.Record // 今日のRecord一覧
 }
 
@@ -90,7 +90,7 @@ func (u *RecordUsecase) GetTodayCalories(ctx context.Context, userID vo.UserID) 
 		Date:           startOfDay,
 		TotalCalories:  totalCalories,
 		TargetCalories: targetCalories,
-		Difference:     totalCalories - targetCalories,
+		Difference:     targetCalories - totalCalories,
 		Records:        records,
 	}, nil
 }

--- a/backend/usecase/record_test.go
+++ b/backend/usecase/record_test.go
@@ -185,8 +185,8 @@ func TestRecordUsecase_GetTodayCalories(t *testing.T) {
 			t.Errorf("TargetCalories = %d, want %d", output.TargetCalories, expectedTargetCalories)
 		}
 
-		// 差分の検証
-		expectedDifference := 900 - expectedTargetCalories
+		// 差分の検証（目標 - 実績）
+		expectedDifference := expectedTargetCalories - 900
 		if output.Difference != expectedDifference {
 			t.Errorf("Difference = %d, want %d", output.Difference, expectedDifference)
 		}

--- a/frontend/src/features/records/components/ProgressRing.test.tsx
+++ b/frontend/src/features/records/components/ProgressRing.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgressRing } from "./ProgressRing";
+
+describe("ProgressRing", () => {
+  describe("パーセンテージ表示", () => {
+    it("パーセンテージが正しく表示されること", () => {
+      render(<ProgressRing progress={50} />);
+      expect(screen.getByText("50")).toBeInTheDocument();
+      expect(screen.getByText("%")).toBeInTheDocument();
+    });
+
+    it("小数点以下が四捨五入されること", () => {
+      render(<ProgressRing progress={33.7} />);
+      expect(screen.getByText("34")).toBeInTheDocument();
+    });
+
+    it("0%が正しく表示されること", () => {
+      render(<ProgressRing progress={0} />);
+      expect(screen.getByText("0")).toBeInTheDocument();
+    });
+
+    it("100%が正しく表示されること", () => {
+      render(<ProgressRing progress={100} />);
+      expect(screen.getByText("100")).toBeInTheDocument();
+    });
+  });
+
+  describe("SVG要素", () => {
+    it("SVG要素がレンダリングされること", () => {
+      const { container } = render(<ProgressRing progress={50} />);
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    it("2つのcircle要素が存在すること", () => {
+      const { container } = render(<ProgressRing progress={50} />);
+      const circles = container.querySelectorAll("circle");
+      expect(circles).toHaveLength(2);
+    });
+  });
+
+  describe("サイズオプション", () => {
+    it("デフォルトサイズが120であること", () => {
+      const { container } = render(<ProgressRing progress={50} />);
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("width", "120");
+      expect(svg).toHaveAttribute("height", "120");
+    });
+
+    it("カスタムサイズが適用されること", () => {
+      const { container } = render(<ProgressRing progress={50} size={200} />);
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveAttribute("width", "200");
+      expect(svg).toHaveAttribute("height", "200");
+    });
+  });
+
+  describe("strokeWidthオプション", () => {
+    it("デフォルトstrokeWidthが8であること", () => {
+      const { container } = render(<ProgressRing progress={50} />);
+      const circles = container.querySelectorAll("circle");
+      circles.forEach((circle) => {
+        expect(circle).toHaveAttribute("stroke-width", "8");
+      });
+    });
+
+    it("カスタムstrokeWidthが適用されること", () => {
+      const { container } = render(<ProgressRing progress={50} strokeWidth={12} />);
+      const circles = container.querySelectorAll("circle");
+      circles.forEach((circle) => {
+        expect(circle).toHaveAttribute("stroke-width", "12");
+      });
+    });
+  });
+
+  describe("プログレス計算", () => {
+    it("0%の場合、strokeDashoffsetが最大になること", () => {
+      const { container } = render(<ProgressRing progress={0} />);
+      const progressCircle = container.querySelectorAll("circle")[1];
+      const radius = (120 - 8) / 2;
+      const circumference = radius * 2 * Math.PI;
+      expect(progressCircle).toHaveAttribute(
+        "stroke-dashoffset",
+        String(circumference)
+      );
+    });
+
+    it("100%の場合、strokeDashoffsetが0になること", () => {
+      const { container } = render(<ProgressRing progress={100} />);
+      const progressCircle = container.querySelectorAll("circle")[1];
+      expect(progressCircle).toHaveAttribute("stroke-dashoffset", "0");
+    });
+
+    it("50%の場合、strokeDashoffsetが半分になること", () => {
+      const { container } = render(<ProgressRing progress={50} />);
+      const progressCircle = container.querySelectorAll("circle")[1];
+      const radius = (120 - 8) / 2;
+      const circumference = radius * 2 * Math.PI;
+      const expectedOffset = circumference - (50 / 100) * circumference;
+      expect(progressCircle).toHaveAttribute(
+        "stroke-dashoffset",
+        String(expectedOffset)
+      );
+    });
+  });
+
+  describe("境界値", () => {
+    it("負の値が渡された場合も動作すること", () => {
+      const { container } = render(<ProgressRing progress={-10} />);
+      expect(screen.getByText("-10")).toBeInTheDocument();
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+
+    it("100を超える値が渡された場合も動作すること", () => {
+      const { container } = render(<ProgressRing progress={150} />);
+      expect(screen.getByText("150")).toBeInTheDocument();
+      expect(container.querySelector("svg")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/features/records/components/ProgressRing.tsx
+++ b/frontend/src/features/records/components/ProgressRing.tsx
@@ -1,0 +1,57 @@
+type ProgressRingProps = {
+  progress: number; // 0-100
+  size?: number;
+  strokeWidth?: number;
+};
+
+/**
+ * 円形プログレスリングコンポーネント
+ */
+export function ProgressRing({
+  progress,
+  size = 120,
+  strokeWidth = 8,
+}: ProgressRingProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = radius * 2 * Math.PI;
+  const offset = circumference - (progress / 100) * circumference;
+
+  return (
+    <div className="relative inline-flex items-center justify-center">
+      <svg width={size} height={size} className="-rotate-90">
+        {/* 背景円 */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          className="text-muted/20"
+        />
+        {/* プログレス円 */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          className="text-primary transition-all duration-1000 ease-out"
+        />
+      </svg>
+      {/* 中央のパーセンテージ表示 */}
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-3xl font-extrabold tabular-nums tracking-tight bg-gradient-to-br from-primary to-primary/70 bg-clip-text text-transparent drop-shadow-sm">
+          {Math.round(progress)}
+        </span>
+        <span className="text-xs font-medium text-muted-foreground -mt-0.5">
+          %
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/records/components/TodaySummary.tsx
+++ b/frontend/src/features/records/components/TodaySummary.tsx
@@ -2,11 +2,38 @@
  * TodaySummary - 今日のカロリーサマリーコンポーネント
  * 目標・摂取・残りカロリーと記録一覧を表示する
  */
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { ApiErrorResponse } from "@/lib/api";
 import type { TodayRecordsResponse } from "../hooks/useTodayRecords";
-import { newEatenAt } from "@/domain/valueObjects/eatenAt";
+import { newEatenAt, type MealType } from "@/domain/valueObjects/eatenAt";
+import { ProgressRing } from "./ProgressRing";
+import { useCountUp } from "../hooks/useCountUp";
+
+/**
+ * 食事タイプごとの絵文字マップ
+ */
+const MEAL_TYPE_EMOJI: Record<MealType, string> = {
+  breakfast: "🌅",
+  lunch: "☀️",
+  snack: "🍪",
+  dinner: "🌙",
+  lateNight: "🌃",
+};
+
+/**
+ * mealTypeに応じたスタイルクラスを返す
+ */
+function getMealTypeStyle(mealType: MealType): string {
+  const styles: Record<MealType, string> = {
+    breakfast: "bg-orange-100 text-orange-700",
+    lunch: "bg-green-100 text-green-700",
+    snack: "bg-purple-100 text-purple-700",
+    dinner: "bg-blue-100 text-blue-700",
+    lateNight: "bg-gray-100 text-gray-700",
+  };
+  return styles[mealType];
+}
 
 export type TodaySummaryProps = {
   data: TodayRecordsResponse | null;
@@ -18,14 +45,31 @@ export type TodaySummaryProps = {
  * TodaySummary - 今日のカロリーサマリーコンポーネント
  */
 export function TodaySummary({ data, isPending, error }: TodaySummaryProps) {
+  // カウントアップアニメーション用の値
+  const animatedTarget = useCountUp({
+    end: data?.targetCalories ?? 0,
+    duration: 1000,
+    startOnMount: !!data,
+  });
+  const animatedTotal = useCountUp({
+    end: data?.totalCalories ?? 0,
+    duration: 1000,
+    startOnMount: !!data,
+  });
+  const animatedDifference = useCountUp({
+    end: Math.abs(data?.difference ?? 0),
+    duration: 1000,
+    startOnMount: !!data,
+  });
+
   // ローディング状態
   if (isPending && !data) {
     return (
       <div className="space-y-6">
-        <div className="grid gap-4 md:grid-cols-3">
-          {[...Array(3)].map((_, i) => (
+        <div className="grid gap-4 md:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
             <Card key={i}>
-              <CardContent className="pt-6">
+              <CardContent className="pt-6 pb-6">
                 <Skeleton className="h-4 w-20 mb-2" />
                 <Skeleton className="h-10 w-32" />
               </CardContent>
@@ -33,10 +77,7 @@ export function TodaySummary({ data, isPending, error }: TodaySummaryProps) {
           ))}
         </div>
         <Card>
-          <CardHeader>
-            <Skeleton className="h-6 w-24" />
-          </CardHeader>
-          <CardContent>
+          <CardContent className="pt-6">
             <Skeleton className="h-4 w-full mb-2" />
             <Skeleton className="h-4 w-3/4" />
           </CardContent>
@@ -61,80 +102,99 @@ export function TodaySummary({ data, isPending, error }: TodaySummaryProps) {
     return null;
   }
 
-  const remainingCalories = data.targetCalories - data.totalCalories;
-  const isOverTarget = remainingCalories < 0;
+  const isOverTarget = data.difference < 0;
+  const progressPercent = Math.min(
+    (data.totalCalories / data.targetCalories) * 100,
+    100
+  );
 
   return (
     <div className="space-y-6">
       {/* サマリーカード */}
-      <div className="grid gap-4 md:grid-cols-3">
+      <div className="grid gap-4 md:grid-cols-4">
+        {/* プログレスリング */}
+        <Card className="opacity-0 animate-fade-in-up transition-transform hover:scale-[1.02] hover:shadow-lg">
+          <CardContent className="h-full flex flex-col items-center justify-center pt-6 pb-6">
+            <p className="text-sm text-muted-foreground mb-3">達成率</p>
+            <ProgressRing progress={progressPercent} />
+          </CardContent>
+        </Card>
+
         {/* 目標カロリー */}
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-sm text-muted-foreground">目標</p>
-            <p className="text-3xl font-bold">
-              {data.targetCalories.toLocaleString()}
-              <span className="text-base font-normal text-muted-foreground ml-1">
-                kcal
-              </span>
+        <Card className="opacity-0 animate-fade-in-up animation-delay-100 transition-transform hover:scale-[1.02] hover:shadow-lg">
+          <CardContent className="h-full flex flex-col items-center justify-center pt-6 pb-6">
+            <p className="text-sm text-muted-foreground mb-2">目標</p>
+            <p className="text-4xl font-extrabold tabular-nums tracking-tight bg-gradient-to-br from-slate-700 to-slate-500 bg-clip-text text-transparent drop-shadow-sm">
+              {animatedTarget.toLocaleString()}
             </p>
+            <span className="text-xs font-medium text-muted-foreground mt-1">
+              kcal
+            </span>
           </CardContent>
         </Card>
 
         {/* 摂取カロリー */}
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-sm text-muted-foreground">摂取</p>
-            <p className="text-3xl font-bold text-primary">
-              {data.totalCalories.toLocaleString()}
-              <span className="text-base font-normal text-muted-foreground ml-1">
-                kcal
-              </span>
+        <Card className="opacity-0 animate-fade-in-up animation-delay-200 transition-transform hover:scale-[1.02] hover:shadow-lg">
+          <CardContent className="h-full flex flex-col items-center justify-center pt-6 pb-6">
+            <p className="text-sm text-muted-foreground mb-2">摂取</p>
+            <p className="text-4xl font-extrabold tabular-nums tracking-tight bg-gradient-to-br from-blue-600 to-cyan-500 bg-clip-text text-transparent drop-shadow-sm">
+              {animatedTotal.toLocaleString()}
             </p>
+            <span className="text-xs font-medium text-muted-foreground mt-1">
+              kcal
+            </span>
           </CardContent>
         </Card>
 
         {/* 残り/超過カロリー */}
-        <Card>
-          <CardContent className="pt-6">
-            <p className="text-sm text-muted-foreground">
+        <Card className="opacity-0 animate-fade-in-up animation-delay-300 transition-transform hover:scale-[1.02] hover:shadow-lg">
+          <CardContent className="h-full flex flex-col items-center justify-center pt-6 pb-6">
+            <p className="text-sm text-muted-foreground mb-2">
               {isOverTarget ? "超過" : "残り"}
             </p>
             <p
-              className={`text-3xl font-bold ${isOverTarget ? "text-destructive" : "text-green-600"}`}
+              className={`text-4xl font-extrabold tabular-nums tracking-tight bg-clip-text text-transparent drop-shadow-sm ${
+                isOverTarget
+                  ? "bg-gradient-to-br from-red-500 to-orange-500"
+                  : "bg-gradient-to-br from-emerald-500 to-teal-400"
+              }`}
             >
-              {Math.abs(remainingCalories).toLocaleString()}
-              <span className="text-base font-normal text-muted-foreground ml-1">
-                kcal
-              </span>
+              {animatedDifference.toLocaleString()}
             </p>
+            <span className="text-xs font-medium text-muted-foreground mt-1">
+              kcal
+            </span>
           </CardContent>
         </Card>
       </div>
 
       {/* 記録一覧 */}
-      <Card>
-        <CardHeader></CardHeader>
-        <CardContent>
+      <Card className="opacity-0 animate-fade-in-up animation-delay-400">
+        <CardContent className="pt-6">
           {data.records.length === 0 ? (
             <p className="text-sm text-muted-foreground">
               まだ記録がありません
             </p>
           ) : (
             <div className="space-y-4">
-              {data.records.map((record) => {
+              {data.records.map((record, recordIndex) => {
                 const eatenAtResult = newEatenAt(record.eatenAt);
                 if (!eatenAtResult.ok) return null;
                 const eatenAt = eatenAtResult.value;
+                const mealType = eatenAt.mealType();
 
                 return (
                   <div
                     key={record.id}
-                    className="border-b last:border-b-0 pb-4 last:pb-0"
+                    className="border-b last:border-b-0 pb-4 last:pb-0 opacity-0 animate-fade-in"
+                    style={{ animationDelay: `${500 + recordIndex * 100}ms` }}
                   >
                     <p className="text-sm font-medium text-muted-foreground mb-2">
+                      <span className="mr-1">{MEAL_TYPE_EMOJI[mealType]}</span>
                       {eatenAt.formattedTime()}
-                      <span className="ml-2 text-xs bg-muted px-2 py-0.5 rounded">
+                      <span
+                        className={`ml-2 text-xs px-2 py-0.5 rounded ${getMealTypeStyle(mealType)}`}
+                      >
                         {eatenAt.mealTypeLabel()}
                       </span>
                     </p>

--- a/frontend/src/features/records/hooks/useCountUp.test.ts
+++ b/frontend/src/features/records/hooks/useCountUp.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useCountUp } from "./useCountUp";
+
+describe("useCountUp", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("初期値が0であること", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    const { result } = renderHook(() => useCountUp({ end: 100 }));
+    expect(result.current).toBe(0);
+  });
+
+  it("startOnMountがfalseの場合、アニメーションが開始されないこと", () => {
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    const { result } = renderHook(() =>
+      useCountUp({ end: 100, startOnMount: false })
+    );
+
+    // requestAnimationFrameが呼ばれていない
+    expect(rafSpy).not.toHaveBeenCalled();
+    expect(result.current).toBe(0);
+  });
+
+  it("endが0の場合、0を返すこと", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    const { result } = renderHook(() => useCountUp({ end: 0 }));
+    expect(result.current).toBe(0);
+  });
+
+  it("startOnMountがtrueの場合、requestAnimationFrameが呼ばれること", () => {
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    renderHook(() => useCountUp({ end: 100, startOnMount: true }));
+
+    expect(rafSpy).toHaveBeenCalled();
+  });
+
+  it("アンマウント時にcancelAnimationFrameが呼ばれること", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(123);
+    const cancelSpy = vi.spyOn(window, "cancelAnimationFrame");
+
+    const { unmount } = renderHook(() => useCountUp({ end: 100 }));
+    unmount();
+
+    expect(cancelSpy).toHaveBeenCalledWith(123);
+  });
+
+  it("durationを指定できること", () => {
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    const { result } = renderHook(() => useCountUp({ end: 100, duration: 500 }));
+    // 初期状態は0
+    expect(result.current).toBe(0);
+  });
+
+  it("endが変わると再アニメーションされること", () => {
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+
+    const { rerender } = renderHook(
+      ({ end }) => useCountUp({ end, duration: 1000 }),
+      { initialProps: { end: 100 } }
+    );
+
+    const initialCallCount = rafSpy.mock.calls.length;
+
+    // endを変更
+    rerender({ end: 200 });
+
+    // 新しいアニメーションが開始される
+    expect(rafSpy.mock.calls.length).toBeGreaterThan(initialCallCount);
+  });
+});

--- a/frontend/src/features/records/hooks/useCountUp.ts
+++ b/frontend/src/features/records/hooks/useCountUp.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+
+type UseCountUpOptions = {
+  end: number;
+  duration?: number;
+  startOnMount?: boolean;
+};
+
+/**
+ * 数値をカウントアップアニメーションで表示するフック
+ */
+export function useCountUp({
+  end,
+  duration = 1000,
+  startOnMount = true,
+}: UseCountUpOptions) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    if (!startOnMount) return;
+
+    let startTime: number;
+    let animationFrame: number;
+
+    const animate = (timestamp: number) => {
+      if (!startTime) startTime = timestamp;
+      const progress = Math.min((timestamp - startTime) / duration, 1);
+
+      // easeOutQuart イージング
+      const eased = 1 - Math.pow(1 - progress, 4);
+      setCount(Math.floor(eased * end));
+
+      if (progress < 1) {
+        animationFrame = requestAnimationFrame(animate);
+      }
+    };
+
+    animationFrame = requestAnimationFrame(animate);
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [end, duration, startOnMount]);
+
+  return count;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -121,3 +121,39 @@
                 0 4px 16px -4px rgba(139, 115, 85, 0.15);
   }
 }
+
+/* アニメーション */
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.5s ease-out forwards;
+}
+
+.animate-fade-in {
+  animation: fade-in 0.3s ease-out forwards;
+}
+
+/* 遅延用ユーティリティ */
+.animation-delay-100 { animation-delay: 100ms; }
+.animation-delay-200 { animation-delay: 200ms; }
+.animation-delay-300 { animation-delay: 300ms; }
+.animation-delay-400 { animation-delay: 400ms; }
+.animation-delay-500 { animation-delay: 500ms; }


### PR DESCRIPTION
## Summary
- Backend: difference計算を `targetCalories - totalCalories` に修正
- Frontend: CSSアニメーション定義追加（fade-in-up, fade-in, 遅延ユーティリティ）
- Frontend: カウントアップアニメーションフック（useCountUp）追加
- Frontend: 円形プログレスリングコンポーネント（ProgressRing）追加
- Frontend: TodaySummaryにアニメーション、グラデーション、プログレスリング追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)