### PR TITLE
refactor(frontend/hooks): フォームコンポーネントのSWR化

### DIFF
--- a/.claude/rules/clean-architecture.md
+++ b/.claude/rules/clean-architecture.md
@@ -27,3 +27,38 @@ Handler → Usecase → Domain
 - `usecase/` は `domain/` のみimport可
 - `infrastructure/` は `domain/`, `usecase/` をimport可
 - `handler/` は `domain/`, `usecase/` をimport可（`infrastructure/` は不可）
+
+## 集計・計算ロジックの配置
+
+**集計・計算処理はアプリケーション層（Domain/Usecase）で行う。SQLでは行わない。**
+
+### 理由
+
+1. **ビジネスロジックの集約**: 集計ロジック（合計、平均、カウント等）はビジネスルールの一部
+2. **テスタビリティ**: 単体テストが書きやすい
+3. **一貫性**: ロジックがDomain/Usecase層に統一される
+
+### 実装パターン
+
+```go
+// ✅ 正しい: Repositoryはデータ取得のみ
+records, _ := repo.FindByUserIDAndDateRange(ctx, userID, start, end)
+
+// ✅ 正しい: 集計はUsecase/Entity層で行う
+totalCalories := 0
+for _, record := range records {
+    totalCalories += record.TotalCalories()
+}
+```
+
+```go
+// ❌ 禁止: RepositoryでSQLの集計関数を使用
+func (r *repo) GetTotalCalories(ctx, userID) (int, error) {
+    // SELECT SUM(calories) FROM records WHERE user_id = ?
+}
+```
+
+### 例外
+
+- パフォーマンス問題が明確に発生した場合のみ、SQLでの集計を検討
+- その場合も、Usecase層で集計ロジックを定義し、Repositoryは最適化された実装として扱う

--- a/frontend/src/features/auth/components/LoginForm.tsx
+++ b/frontend/src/features/auth/components/LoginForm.tsx
@@ -15,7 +15,6 @@ import {
 import { useForm, getApiErrorMessage } from "@/features/common";
 import { newEmail } from "@/domain/valueObjects/email";
 import { newPassword } from "@/domain/valueObjects/password";
-import { post } from "@/lib/api";
 
 /** ログインレスポンス */
 export type LoginResponse = {
@@ -24,9 +23,11 @@ export type LoginResponse = {
   nickname: string;
 };
 
-/** ログインAPI */
-const login = (data: { email: string; password: string }) =>
-  post<LoginResponse>("/api/v1/auth/login", data);
+/** ログインリクエスト */
+type LoginRequest = {
+  email: string;
+  password: string;
+};
 
 /** LoginFormコンポーネントのProps */
 export type LoginFormProps = {
@@ -101,13 +102,14 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
     handleSubmit,
     isValid,
     isPending,
-  } = useForm(
-    formConfig,
+  } = useForm<LoginField, LoginResponse, LoginRequest>({
+    config: formConfig,
     initialFormState,
     initialErrors,
-    (data) => login({ email: data.email, password: data.password }),
+    url: "/api/v1/auth/login",
+    transformData: (data) => ({ email: data.email, password: data.password }),
     onSuccess,
-  );
+  });
 
   return (
     <Card className="w-full shadow-warm-lg border-0">

--- a/frontend/src/features/auth/components/RegisterForm.tsx
+++ b/frontend/src/features/auth/components/RegisterForm.tsx
@@ -28,7 +28,6 @@ import {
   ACTIVITY_LEVEL_OPTIONS,
 } from "@/domain/valueObjects";
 import type { GenderValue, ActivityLevelValue } from "@/domain/valueObjects";
-import { post } from "@/lib/api";
 
 /** ユーザー登録レスポンス */
 export type RegisterUserResponse = {
@@ -48,10 +47,6 @@ type RegisterUserRequest = {
   gender: GenderValue;
   activityLevel: ActivityLevelValue;
 };
-
-/** ユーザー登録API */
-const registerUser = (data: RegisterUserRequest) =>
-  post<RegisterUserResponse>("/api/v1/auth/register", data);
 
 /** RegisterFormコンポーネントのProps */
 export type RegisterFormProps = {
@@ -155,23 +150,23 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
     handleSubmit,
     isValid,
     isPending,
-  } = useForm(
-    formConfig,
+  } = useForm<RegisterField, RegisterUserResponse, RegisterUserRequest>({
+    config: formConfig,
     initialFormState,
     initialErrors,
-    (data) =>
-      registerUser({
-        email: data.email,
-        password: data.password,
-        nickname: data.nickname,
-        weight: parseFloat(data.weight),
-        height: parseFloat(data.height),
-        birthDate: data.birthDate,
-        gender: data.gender as GenderValue,
-        activityLevel: data.activityLevel as ActivityLevelValue,
-      }),
-    onSuccess
-  );
+    url: "/api/v1/auth/register",
+    transformData: (data) => ({
+      email: data.email,
+      password: data.password,
+      nickname: data.nickname,
+      weight: parseFloat(data.weight),
+      height: parseFloat(data.height),
+      birthDate: data.birthDate,
+      gender: data.gender as GenderValue,
+      activityLevel: data.activityLevel as ActivityLevelValue,
+    }),
+    onSuccess,
+  });
 
   return (
     <Card className="w-full shadow-warm-lg border-0">

--- a/frontend/src/features/common/hooks/index.ts
+++ b/frontend/src/features/common/hooks/index.ts
@@ -2,6 +2,6 @@
  * Common Hooks
  */
 export { useForm } from "./useForm";
-export type { UseFormReturn } from "./useForm";
+export type { UseFormReturn, UseFormOptions } from "./useForm";
 
 export { useRequest, useRequestGet, useRequestMutation } from "./useRequest";

--- a/frontend/src/features/common/index.ts
+++ b/frontend/src/features/common/index.ts
@@ -12,4 +12,4 @@ export {
 
 // Hooks
 export { useForm } from "./hooks";
-export type { UseFormReturn } from "./hooks";
+export type { UseFormReturn, UseFormOptions } from "./hooks";

--- a/frontend/src/features/records/components/RecordForm.test.tsx
+++ b/frontend/src/features/records/components/RecordForm.test.tsx
@@ -6,19 +6,24 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RecordForm } from "./RecordForm";
 
-// APIをモック
-vi.mock("@/lib/api", () => ({
-  post: vi.fn(),
+// SWR mutateをモック
+const mockTrigger = vi.fn();
+vi.mock("@/features/common/hooks", () => ({
+  useRequestMutation: () => ({
+    trigger: mockTrigger,
+    isMutating: false,
+    error: undefined,
+    data: undefined,
+    reset: vi.fn(),
+  }),
 }));
-
-import { post } from "@/lib/api";
 
 describe("RecordForm", () => {
   const mockOnSuccess = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(post).mockResolvedValue({
+    mockTrigger.mockResolvedValue({
       recordId: "test-id",
       eatenAt: "2024-01-01T12:00:00Z",
       totalCalories: 250,
@@ -212,9 +217,8 @@ describe("RecordForm", () => {
       fireEvent.click(screen.getByRole("button", { name: "記録する" }));
 
       await waitFor(() => {
-        expect(post).toHaveBeenCalledTimes(1);
-        expect(post).toHaveBeenCalledWith(
-          "/api/v1/records",
+        expect(mockTrigger).toHaveBeenCalledTimes(1);
+        expect(mockTrigger).toHaveBeenCalledWith(
           expect.objectContaining({
             items: [{ name: "白米", calories: 250 }],
           })

--- a/frontend/src/features/records/hooks/useTodayRecords.ts
+++ b/frontend/src/features/records/hooks/useTodayRecords.ts
@@ -1,7 +1,7 @@
 /**
  * useTodayRecords - 今日のカロリー記録取得フック
  */
-import { useRequest } from "@/features/common/hooks";
+import { useRequestGet } from "@/features/common/hooks";
 
 type RecordItem = {
   itemId: string;
@@ -24,7 +24,7 @@ export type TodayRecordsResponse = {
 };
 
 export function useTodayRecords() {
-  const { data, error, isLoading, mutate } = useRequest<TodayRecordsResponse>(
+  const { data, error, isLoading, mutate } = useRequestGet<TodayRecordsResponse>(
     "/api/v1/records/today"
   );
 


### PR DESCRIPTION
## Summary
- useFormフックをSWR mutationベースに変更
- LoginForm, RegisterForm, RecordFormをSWR対応に更新
- useTodayRecordsでmutate連携を追加
- テストをSWRモック方式に更新
- clean-architecture.mdに集計ロジックの配置ルールを追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)