### PR TITLE
feat(frontend/lib): 401エラー時にログイン画面へリダイレクト

### DIFF
--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -2,6 +2,22 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { request, get, post, put, del, apiClient } from "./api";
 import { AxiosError, AxiosHeaders, AxiosResponse } from "axios";
 
+/** routerのモック（vi.hoistedでホイスト対応） */
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+}));
+
+vi.mock("@/routes", () => ({
+  router: {
+    state: {
+      location: {
+        pathname: "/dashboard",
+      },
+    },
+    navigate: mockNavigate,
+  },
+}));
+
 vi.mock("axios", async () => {
   const actual = await vi.importActual("axios");
   return {
@@ -12,6 +28,11 @@ vi.mock("axios", async () => {
         post: vi.fn(),
         put: vi.fn(),
         delete: vi.fn(),
+        interceptors: {
+          response: {
+            use: vi.fn(),
+          },
+        },
       })),
     },
   };


### PR DESCRIPTION
## Summary
- axiosインターセプターで401レスポンスを検知し、ログイン画面へリダイレクト
- ログイン画面（/）以外にいる場合のみリダイレクトを実行
- routerのモックを追加してテスト対応

## Test plan
- [x] Build: Pass
- [x] Test: Pass

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)