### PR TITLE
refactor(lib): api.tsから未使用関数を削除

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -56,37 +56,3 @@ apiClient.interceptors.response.use(
     return Promise.reject(error);
   }
 );
-
-/**
- * APIエラーをApiErrorResponse形式に変換
- */
-function handleApiError(error: unknown): ApiErrorResponse {
-  if (error instanceof AxiosError && error.response?.data) {
-    return error.response.data as ApiErrorResponse;
-  }
-  return {
-    code: "INTERNAL_ERROR",
-    message: "予期しないエラーが発生しました",
-  };
-}
-
-/**
- * request - 汎用APIリクエスト
- */
-export async function request<T>(
-  request: Promise<AxiosResponse<T>>
-): Promise<T> {
-  try {
-    const response = await request;
-    return response.data;
-  } catch (error) {
-    throw handleApiError(error);
-  }
-}
-
-export const get = <T>(url: string) => request(apiClient.get<T>(url));
-export const post = <T, D = unknown>(url: string, data?: D) =>
-  request(apiClient.post<T>(url, data));
-export const put = <T, D = unknown>(url: string, data?: D) =>
-  request(apiClient.put<T>(url, data));
-export const del = <T>(url: string) => request(apiClient.delete<T>(url));


### PR DESCRIPTION
## Summary
- request, get, post, put, del 関数を削除
- 対応するテストも削除
- apiClientのみをエクスポート

## Test plan
- [x] Build: Pass
- [x] Test: Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)