### PR TITLE
refactor: docker-compose.ymlの環境変数をハードコードから参照に変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,11 +27,11 @@ services:
     env_file:
       - ./.env
     environment:
-      - DB_HOST=mysql
-      - DB_PORT=3306
-      - DB_USER=caltrack
-      - DB_PASSWORD=caltrack
-      - DB_NAME=caltrack
+      - DB_HOST=${DB_HOST:-mysql}
+      - DB_PORT=${DB_PORT:-3306}
+      - DB_USER=${DB_USER:-caltrack}
+      - DB_PASSWORD=${DB_PASSWORD:-caltrack}
+      - DB_NAME=${DB_NAME:-caltrack}
     depends_on:
       mysql:
         condition: service_healthy
@@ -43,10 +43,10 @@ services:
     ports:
       - "3307:3306"
     environment:
-      - MYSQL_ROOT_PASSWORD=rootpassword
-      - MYSQL_DATABASE=caltrack
-      - MYSQL_USER=caltrack
-      - MYSQL_PASSWORD=caltrack
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-rootpassword}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-caltrack}
+      - MYSQL_USER=${MYSQL_USER:-caltrack}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-caltrack}
     volumes:
       - mysql-data:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
## Summary
- docker-compose.ymlの環境変数をハードコードから.env参照に変更
- セキュリティ向上と環境ごとの設定管理を容易に

## Test plan
- [x] docker-compose.ymlの構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)