### PR TITLE
fix(ci): rsyncの除外対象に.envを追加

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
             --exclude '.git' \
             --exclude 'node_modules' \
             --exclude 'frontend/node_modules' \
+            --exclude '.env' \
             ./ ${{ secrets.LIGHTSAIL_USER }}@${{ secrets.LIGHTSAIL_HOST }}:~/my-app/
 
           ssh ${{ secrets.LIGHTSAIL_USER }}@${{ secrets.LIGHTSAIL_HOST }} "cd ~/my-app && docker compose up -d --build"


### PR DESCRIPTION
## Summary
- rsyncコマンドの除外オプションに`.env`を追加
- デプロイ時に環境変数ファイルが本番サーバーに上書きされることを防止

## Test plan
- [x] YAMLの構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)