### PR TITLE
feat(config): CORS許可オリジンとVite許可ホストを環境変数化

### DIFF
--- a/backend/config/server.go
+++ b/backend/config/server.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"os"
+	"strings"
+)
+
+const defaultCORSAllowOrigins = "http://localhost:5173"
+
+// GetCORSAllowOrigins は CORS で許可するオリジンを取得する
+// 環境変数 CORS_ALLOW_ORIGINS から取得し、未設定の場合はデフォルト値を使用
+// 複数オリジンはカンマ区切りで指定
+func GetCORSAllowOrigins() []string {
+	originsStr := os.Getenv("CORS_ALLOW_ORIGINS")
+	if originsStr == "" {
+		originsStr = defaultCORSAllowOrigins
+	}
+
+	origins := strings.Split(originsStr, ",")
+	result := make([]string, 0, len(origins))
+	for _, origin := range origins {
+		trimmed := strings.TrimSpace(origin)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -71,7 +71,7 @@ func main() {
 
 	// CORS configuration
 	r.Use(cors.New(cors.Config{
-		AllowOrigins:     []string{"http://localhost:5173"},
+		AllowOrigins:     config.GetCORSAllowOrigins(),
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
 		AllowCredentials: true,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,19 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+// allowedHosts を環境変数から取得
+// VITE_ALLOWED_HOSTS: カンマ区切りで複数指定可能
+function getAllowedHosts(): string[] | true {
+  const hostsEnv = process.env.VITE_ALLOWED_HOSTS
+  if (!hostsEnv) {
+    return ['localhost']
+  }
+  if (hostsEnv.toLowerCase() === 'all') {
+    return true
+  }
+  return hostsEnv.split(',').map(host => host.trim()).filter(host => host !== '')
+}
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -13,6 +26,7 @@ export default defineConfig({
   server: {
     host: '0.0.0.0',
     port: 5173,
+    allowedHosts: getAllowedHosts(),
     watch: {
       usePolling: true,
     },


### PR DESCRIPTION
## Summary
- backend/config/server.goを追加（CORS_ALLOW_ORIGINS環境変数対応）
- backend/main.goでGetCORSAllowOriginsを使用するよう変更
- frontend/vite.config.tsでVITE_ALLOWED_HOSTS環境変数対応

## Test plan
- [x] Build: Pass
- [x] 動作確認済み

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)