### PR TITLE
fix(docker): frontendサービスにVITE_ALLOWED_HOSTS環境変数を追加

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - /app/node_modules
     environment:
       - VITE_API_URL=http://localhost:8080
+      - VITE_ALLOWED_HOSTS=${VITE_ALLOWED_HOSTS:-localhost}
     depends_on:
       - backend
     networks:


### PR DESCRIPTION
## Summary
- frontendサービスにVITE_ALLOWED_HOSTS環境変数を追加
- 環境変数でホスト制限を設定可能に
- デフォルト値としてlocalhostを設定

## Test plan
- [x] docker-compose.yml構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)