### PR TITLE
feat(frontend): API URLを環境変数化

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ./frontend:/app
       - /app/node_modules
     environment:
-      - VITE_API_URL=http://localhost:8080
+      - VITE_API_URL=${VITE_API_URL:-http://localhost:8080}
       - VITE_ALLOWED_HOSTS=${VITE_ALLOWED_HOSTS:-localhost}
     depends_on:
       - backend

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -31,7 +31,7 @@ export type ApiErrorResponse = {
 };
 
 export const apiClient = axios.create({
-  baseURL: "http://localhost:8080",
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:8080",
   timeout: 10000,
   headers: {
     "Content-Type": "application/json",

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -3,7 +3,7 @@
  *
  * 既存のApp.tsxの内容をページコンポーネントとして切り出し
  */
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -29,14 +29,17 @@ export function HomePage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  /** API URL（環境変数から取得、デフォルトはlocalhost） */
+  const apiUrl = import.meta.env.VITE_API_URL || "http://localhost:8080";
+
   /**
    * バックエンドのヘルスチェックを実行
    */
-  const checkHealth = async () => {
+  const checkHealth = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch("http://localhost:8080/health");
+      const response = await fetch(`${apiUrl}/health`);
       const data = await response.json();
       setHealth(data);
     } catch {
@@ -45,11 +48,11 @@ export function HomePage() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [apiUrl]);
 
   useEffect(() => {
     checkHealth();
-  }, []);
+  }, [checkHealth]);
 
   return (
     <div className="min-h-screen bg-background flex items-center justify-center p-4">

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,13 @@
+/// <reference types="vite/client" />
+
+/**
+ * Vite環境変数の型定義
+ */
+interface ImportMetaEnv {
+  /** API URL（バックエンドのベースURL） */
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- docker-compose.ymlでVITE_API_URLを環境変数参照に変更
- api.tsのbaseURLを環境変数から取得するよう変更
- HomePage.tsxのfetch URLを環境変数から取得するよう変更
- vite-env.d.tsを追加してVite環境変数の型定義

## Test plan
- [x] Build: Pass
- [x] 環境変数でAPI URLが切り替わることを確認

Generated with [Claude Code](https://claude.com/claude-code)