### PR TITLE
fix(nginx): client_max_body_sizeを20Mに設定

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -6,6 +6,9 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
+    # リクエストボディの最大サイズ（画像解析用に余裕を持たせる）
+    client_max_body_size 20M;
+
     server {
         listen 80;
         server_name _;


### PR DESCRIPTION
## Summary
- 画像解析用にリクエストボディの最大サイズを20Mに設定

## Test plan
- [x] nginx設定の構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)