### PR TITLE
fix(frontend): 画像解析のタイムアウトを120秒に設定

### DIFF
--- a/frontend/src/features/records/hooks/useImageAnalysis.ts
+++ b/frontend/src/features/records/hooks/useImageAnalysis.ts
@@ -3,7 +3,8 @@
  * 画像から食品情報を解析する
  */
 import { useCallback, useState } from "react";
-import { useRequestMutation } from "@/features/common/hooks";
+import { AxiosError } from "axios";
+import { apiClient, type ApiErrorResponse } from "@/lib/api";
 import { getApiErrorMessage } from "@/features/common/helpers";
 import type { ImageFile } from "@/domain/valueObjects/imageFile";
 
@@ -42,56 +43,75 @@ type UseImageAnalysisReturn = {
 /** APIエンドポイント */
 const IMAGE_ANALYSIS_ENDPOINT = "/api/v1/analyze-image";
 
+/** 画像解析用タイムアウト: 120秒（AI処理に時間がかかるため延長） */
+const IMAGE_ANALYSIS_TIMEOUT_MS = 120000;
+
 /**
  * useImageAnalysis - 画像解析フック
+ * 画像解析はAI処理のため時間がかかるので、タイムアウトを120秒に設定
  */
 export function useImageAnalysis(
   options?: UseImageAnalysisOptions
 ): UseImageAnalysisReturn {
   const [error, setError] = useState<string | null>(null);
-
-  const {
-    trigger,
-    data,
-    isMutating,
-    reset: resetMutation,
-  } = useRequestMutation<ImageAnalysisResponse, ImageAnalysisRequest>(
-    IMAGE_ANALYSIS_ENDPOINT,
-    "POST",
-    {
-      onSuccess: (responseData) => {
-        setError(null);
-        options?.onSuccess?.(responseData);
-      },
-      onError: (apiError) => {
-        const errorMessage = getApiErrorMessage(apiError.code);
-        setError(errorMessage);
-        options?.onError?.(errorMessage);
-      },
-    }
-  );
+  const [data, setData] = useState<ImageAnalysisResponse | undefined>(undefined);
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
 
   const analyze = useCallback(
     async (imageFile: ImageFile): Promise<void> => {
       setError(null);
-      await trigger({
-        imageData: imageFile.base64,
-        mimeType: imageFile.mimeType,
-      });
+      setIsAnalyzing(true);
+
+      try {
+        const response = await apiClient.post<ImageAnalysisResponse>(
+          IMAGE_ANALYSIS_ENDPOINT,
+          {
+            imageData: imageFile.base64,
+            mimeType: imageFile.mimeType,
+          } satisfies ImageAnalysisRequest,
+          {
+            timeout: IMAGE_ANALYSIS_TIMEOUT_MS,
+          }
+        );
+
+        setData(response.data);
+        options?.onSuccess?.(response.data);
+      } catch (e) {
+        let apiError: ApiErrorResponse = {
+          code: "INTERNAL_ERROR",
+          message: "予期しないエラーが発生しました",
+        };
+
+        if (e instanceof AxiosError && e.response?.data) {
+          apiError = e.response.data as ApiErrorResponse;
+        } else if (e instanceof AxiosError && e.code === "ECONNABORTED") {
+          // タイムアウトエラー
+          apiError = {
+            code: "IMAGE_ANALYSIS_FAILED",
+            message: "画像解析がタイムアウトしました。しばらく経ってから再度お試しください。",
+          };
+        }
+
+        const errorMessage = getApiErrorMessage(apiError.code);
+        setError(errorMessage);
+        options?.onError?.(errorMessage);
+      } finally {
+        setIsAnalyzing(false);
+      }
     },
-    [trigger]
+    [options]
   );
 
   const reset = useCallback(() => {
     setError(null);
-    resetMutation();
-  }, [resetMutation]);
+    setData(undefined);
+  }, []);
 
   return {
     analyze,
     data,
     error,
-    isAnalyzing: isMutating,
+    isAnalyzing,
     reset,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,6 +32,8 @@ export type ApiErrorResponse = {
 
 export const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_URL || "http://localhost:8080",
+  // デフォルトタイムアウト: 10秒
+  // 画像解析など長時間処理が必要なリクエストは、呼び出し側でtimeoutを上書きする
   timeout: 10000,
   headers: {
     "Content-Type": "application/json",

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -31,6 +31,11 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # タイムアウト設定（画像解析用に延長）
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 120s;
+            proxy_read_timeout 120s;
         }
 
         # ヘルスチェック


### PR DESCRIPTION
## Summary
- nginx: proxy_read_timeout, proxy_send_timeoutを120秒に設定
- apiClient: デフォルトタイムアウトのコメント追加
- useImageAnalysis: タイムアウト120秒でAPIを直接呼び出すように変更
- useImageAnalysis.test.ts: apiClientモックに変更、タイムアウトテスト追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)