### PR TITLE
fix(infra): セキュリティ強化 - MySQLポート閉鎖とCloudflare経由のみ許可

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,6 @@ services:
 
   mysql:
     image: mysql:8.0
-    ports:
-      - "3307:3306"
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-rootpassword}
       - MYSQL_DATABASE=${MYSQL_DATABASE:-caltrack}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -9,9 +9,22 @@ http {
     # リクエストボディの最大サイズ（画像解析用に余裕を持たせる）
     client_max_body_size 20M;
 
+    # IP直接アクセスを拒否するデフォルトサーバー
+    server {
+        listen 80 default_server;
+        server_name _;
+        return 444;
+    }
+
+    # メインサーバー（ドメイン名でのアクセスのみ許可）
     server {
         listen 80;
-        server_name _;
+        server_name caltracks.win;
+
+        # Cloudflare経由のアクセスのみ許可
+        if ($http_cf_connecting_ip = "") {
+            return 403;
+        }
 
         # フロントエンド
         location / {


### PR DESCRIPTION
## Summary
- docker-compose.ymlからMySQLの外部ポートマッピング(3307:3306)を削除
- nginx.confでIP直接アクセスを拒否するdefault_serverを追加
- Cloudflare経由のアクセスのみ許可（cf-connecting-ipヘッダーチェック）

## Test plan
- [x] docker-compose.yml: ポートマッピング削除を確認
- [x] nginx.conf: IP直接アクセス拒否設定を確認
- [x] nginx.conf: Cloudflareヘッダーチェック設定を確認

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)