### PR TITLE
fix(ci): ビルド時にVITE_API_URLを設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
           node-version: '20'
 
       - name: Build frontend
+        env:
+          VITE_API_URL: https://caltracks.win
         run: |
           cd frontend
           npm ci


### PR DESCRIPTION
## Summary
- frontendビルド時に環境変数VITE_API_URLを設定
- 本番APIエンドポイント(https://caltracks.win)への接続を有効化

## Test plan
- [x] GitHub Actionsワークフローの構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)