### PR TITLE
fix(frontend): Safariでdatetime-localの横幅がはみ出す問題を修正

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -15,7 +15,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full max-w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "[&::-webkit-datetime-edit]:max-w-full [&::-webkit-datetime-edit-fields-wrapper]:max-w-full",
           className
         )}
         ref={ref}


### PR DESCRIPTION
## Summary
- max-w-fullを追加して最大幅を親要素に制限
- webkit-datetime-edit疑似要素にmax-w-fullを適用してSafariでの表示崩れを修正

## Test plan
- [x] Build: Pass
- [x] Test: Pass (実機確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)