### PR TITLE
fix(frontend): Safariでのdatetime-local表示問題を修正

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -15,7 +15,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full max-w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "flex h-10 w-full max-w-full min-w-0 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
           "[&::-webkit-datetime-edit]:max-w-full [&::-webkit-datetime-edit-fields-wrapper]:max-w-full",
           className
         )}

--- a/frontend/src/features/records/components/RecordDialog.tsx
+++ b/frontend/src/features/records/components/RecordDialog.tsx
@@ -60,7 +60,10 @@ export function RecordDialog({ onSuccess }: RecordDialogProps) {
           記録する
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto">
+      <DialogContent
+        className="max-w-lg max-h-[90vh] overflow-y-auto"
+        onOpenAutoFocus={(e) => e.preventDefault()}
+      >
         <DialogHeader>
           <DialogTitle>カロリー記録</DialogTitle>
         </DialogHeader>


### PR DESCRIPTION
## Summary
- inputにmin-w-0を追加しグリッド内で収縮可能に
- DialogContentにonOpenAutoFocusを追加し自動カレンダー表示を防止

## Test plan
- [x] Build: Pass
- [x] 実機確認: Safari/iPhoneで動作検証済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)