### PR TITLE
refactor(domain): UUID VO統一 + RecordPfc Entity追加

### DIFF
--- a/backend/domain/entity/record_pfc.go
+++ b/backend/domain/entity/record_pfc.go
@@ -1,0 +1,58 @@
+package entity
+
+import "caltrack/domain/vo"
+
+// RecordPfc はカロリー記録のPFC情報を表すEntity
+type RecordPfc struct {
+	id       vo.RecordPfcID
+	recordID vo.RecordID
+	pfc      vo.Pfc
+}
+
+// NewRecordPfc は新しいRecordPfcを生成する
+func NewRecordPfc(recordID vo.RecordID, protein, fat, carbs float64) *RecordPfc {
+	return &RecordPfc{
+		id:       vo.NewRecordPfcID(),
+		recordID: recordID,
+		pfc:      vo.NewPfc(protein, fat, carbs),
+	}
+}
+
+// ReconstructRecordPfc はDBからRecordPfcを復元する
+func ReconstructRecordPfc(idStr, recordIDStr string, protein, fat, carbs float64) *RecordPfc {
+	return &RecordPfc{
+		id:       vo.ReconstructRecordPfcID(idStr),
+		recordID: vo.ReconstructRecordID(recordIDStr),
+		pfc:      vo.NewPfc(protein, fat, carbs),
+	}
+}
+
+// ID はRecordPfcIDを返す
+func (r *RecordPfc) ID() vo.RecordPfcID {
+	return r.id
+}
+
+// RecordID はRecordIDを返す
+func (r *RecordPfc) RecordID() vo.RecordID {
+	return r.recordID
+}
+
+// Pfc はPfc情報を返す
+func (r *RecordPfc) Pfc() vo.Pfc {
+	return r.pfc
+}
+
+// Protein はタンパク質(g)を返す
+func (r *RecordPfc) Protein() float64 {
+	return r.pfc.Protein()
+}
+
+// Fat は脂質(g)を返す
+func (r *RecordPfc) Fat() float64 {
+	return r.pfc.Fat()
+}
+
+// Carbs は炭水化物(g)を返す
+func (r *RecordPfc) Carbs() float64 {
+	return r.pfc.Carbs()
+}

--- a/backend/domain/entity/record_pfc_test.go
+++ b/backend/domain/entity/record_pfc_test.go
@@ -1,0 +1,150 @@
+package entity_test
+
+import (
+	"testing"
+
+	"caltrack/domain/entity"
+	"caltrack/domain/vo"
+)
+
+func TestNewRecordPfc(t *testing.T) {
+	t.Run("正常系_有効なパラメータでRecordPfc作成", func(t *testing.T) {
+		recordID := vo.NewRecordID()
+		protein := 20.5
+		fat := 10.3
+		carbs := 50.8
+
+		recordPfc := entity.NewRecordPfc(recordID, protein, fat, carbs)
+
+		if recordPfc == nil {
+			t.Fatal("NewRecordPfc() returned nil")
+		}
+		if !recordPfc.RecordID().Equals(recordID) {
+			t.Errorf("NewRecordPfc().RecordID() = %v, want %v", recordPfc.RecordID(), recordID)
+		}
+		if recordPfc.ID().String() == "" {
+			t.Error("NewRecordPfc().ID() should not be empty")
+		}
+		if recordPfc.Protein() != protein {
+			t.Errorf("NewRecordPfc().Protein() = %v, want %v", recordPfc.Protein(), protein)
+		}
+		if recordPfc.Fat() != fat {
+			t.Errorf("NewRecordPfc().Fat() = %v, want %v", recordPfc.Fat(), fat)
+		}
+		if recordPfc.Carbs() != carbs {
+			t.Errorf("NewRecordPfc().Carbs() = %v, want %v", recordPfc.Carbs(), carbs)
+		}
+	})
+
+	t.Run("正常系_0の値も許容される", func(t *testing.T) {
+		recordID := vo.NewRecordID()
+		protein := 0.0
+		fat := 0.0
+		carbs := 0.0
+
+		recordPfc := entity.NewRecordPfc(recordID, protein, fat, carbs)
+
+		if recordPfc == nil {
+			t.Fatal("NewRecordPfc() returned nil")
+		}
+		if recordPfc.Protein() != 0.0 {
+			t.Errorf("NewRecordPfc().Protein() = %v, want 0.0", recordPfc.Protein())
+		}
+		if recordPfc.Fat() != 0.0 {
+			t.Errorf("NewRecordPfc().Fat() = %v, want 0.0", recordPfc.Fat())
+		}
+		if recordPfc.Carbs() != 0.0 {
+			t.Errorf("NewRecordPfc().Carbs() = %v, want 0.0", recordPfc.Carbs())
+		}
+	})
+
+	t.Run("正常系_小数点以下も正しく保持される", func(t *testing.T) {
+		recordID := vo.NewRecordID()
+		protein := 20.123
+		fat := 10.456
+		carbs := 50.789
+
+		recordPfc := entity.NewRecordPfc(recordID, protein, fat, carbs)
+
+		if recordPfc.Protein() != protein {
+			t.Errorf("NewRecordPfc().Protein() = %v, want %v", recordPfc.Protein(), protein)
+		}
+		if recordPfc.Fat() != fat {
+			t.Errorf("NewRecordPfc().Fat() = %v, want %v", recordPfc.Fat(), fat)
+		}
+		if recordPfc.Carbs() != carbs {
+			t.Errorf("NewRecordPfc().Carbs() = %v, want %v", recordPfc.Carbs(), carbs)
+		}
+	})
+}
+
+func TestReconstructRecordPfc(t *testing.T) {
+	t.Run("DB復元", func(t *testing.T) {
+		idStr := "550e8400-e29b-41d4-a716-446655440000"
+		recordIDStr := "660e8400-e29b-41d4-a716-446655440001"
+		protein := 20.5
+		fat := 10.3
+		carbs := 50.8
+
+		recordPfc := entity.ReconstructRecordPfc(idStr, recordIDStr, protein, fat, carbs)
+
+		if recordPfc.ID().String() != idStr {
+			t.Errorf("ReconstructRecordPfc().ID() = %v, want %v", recordPfc.ID().String(), idStr)
+		}
+		if recordPfc.RecordID().String() != recordIDStr {
+			t.Errorf("ReconstructRecordPfc().RecordID() = %v, want %v", recordPfc.RecordID().String(), recordIDStr)
+		}
+		if recordPfc.Protein() != protein {
+			t.Errorf("ReconstructRecordPfc().Protein() = %v, want %v", recordPfc.Protein(), protein)
+		}
+		if recordPfc.Fat() != fat {
+			t.Errorf("ReconstructRecordPfc().Fat() = %v, want %v", recordPfc.Fat(), fat)
+		}
+		if recordPfc.Carbs() != carbs {
+			t.Errorf("ReconstructRecordPfc().Carbs() = %v, want %v", recordPfc.Carbs(), carbs)
+		}
+	})
+
+	t.Run("DB復元_0の値も正しく復元される", func(t *testing.T) {
+		idStr := "550e8400-e29b-41d4-a716-446655440000"
+		recordIDStr := "660e8400-e29b-41d4-a716-446655440001"
+		protein := 0.0
+		fat := 0.0
+		carbs := 0.0
+
+		recordPfc := entity.ReconstructRecordPfc(idStr, recordIDStr, protein, fat, carbs)
+
+		if recordPfc.Protein() != 0.0 {
+			t.Errorf("ReconstructRecordPfc().Protein() = %v, want 0.0", recordPfc.Protein())
+		}
+		if recordPfc.Fat() != 0.0 {
+			t.Errorf("ReconstructRecordPfc().Fat() = %v, want 0.0", recordPfc.Fat())
+		}
+		if recordPfc.Carbs() != 0.0 {
+			t.Errorf("ReconstructRecordPfc().Carbs() = %v, want 0.0", recordPfc.Carbs())
+		}
+	})
+}
+
+func TestRecordPfc_Pfc(t *testing.T) {
+	t.Run("Pfc VOを取得できる", func(t *testing.T) {
+		recordID := vo.NewRecordID()
+		protein := 20.5
+		fat := 10.3
+		carbs := 50.8
+
+		recordPfc := entity.NewRecordPfc(recordID, protein, fat, carbs)
+
+		pfc := recordPfc.Pfc()
+
+		if pfc.Protein() != protein {
+			t.Errorf("Pfc().Protein() = %v, want %v", pfc.Protein(), protein)
+		}
+		if pfc.Fat() != fat {
+			t.Errorf("Pfc().Fat() = %v, want %v", pfc.Fat(), fat)
+		}
+		if pfc.Carbs() != carbs {
+			t.Errorf("Pfc().Carbs() = %v, want %v", pfc.Carbs(), carbs)
+		}
+	})
+}

--- a/backend/domain/entity/record_test.go
+++ b/backend/domain/entity/record_test.go
@@ -112,13 +112,13 @@ func TestRecord_AddItem(t *testing.T) {
 
 func TestReconstructRecord(t *testing.T) {
 	t.Run("DB復元", func(t *testing.T) {
-		idStr := "record-123"
-		userIDStr := "user-456"
+		idStr := "550e8400-e29b-41d4-a716-446655440000"
+		userIDStr := "660e8400-e29b-41d4-a716-446655440001"
 		eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 		createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
 		items := []entity.RecordItem{
-			*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
-			*entity.ReconstructRecordItem("item-2", idStr, "味噌汁", 50),
+			*entity.ReconstructRecordItem("770e8400-e29b-41d4-a716-446655440002", idStr, "おにぎり", 180),
+			*entity.ReconstructRecordItem("880e8400-e29b-41d4-a716-446655440003", idStr, "味噌汁", 50),
 		}
 
 		record := entity.ReconstructRecord(idStr, userIDStr, eatenAtTime, createdAt, items)
@@ -142,8 +142,8 @@ func TestReconstructRecord(t *testing.T) {
 }
 
 func TestRecord_TotalCalories(t *testing.T) {
-	idStr := "record-123"
-	userIDStr := "user-456"
+	idStr := "550e8400-e29b-41d4-a716-446655440000"
+	userIDStr := "660e8400-e29b-41d4-a716-446655440001"
 	eatenAtTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 	createdAt := time.Date(2024, 6, 15, 12, 30, 0, 0, time.UTC)
 
@@ -155,16 +155,16 @@ func TestRecord_TotalCalories(t *testing.T) {
 		{
 			name: "単一アイテム",
 			items: []entity.RecordItem{
-				*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
+				*entity.ReconstructRecordItem("770e8400-e29b-41d4-a716-446655440002", idStr, "おにぎり", 180),
 			},
 			wantTotal: 180,
 		},
 		{
 			name: "複数アイテム",
 			items: []entity.RecordItem{
-				*entity.ReconstructRecordItem("item-1", idStr, "おにぎり", 180),
-				*entity.ReconstructRecordItem("item-2", idStr, "味噌汁", 50),
-				*entity.ReconstructRecordItem("item-3", idStr, "焼き鮭", 200),
+				*entity.ReconstructRecordItem("770e8400-e29b-41d4-a716-446655440002", idStr, "おにぎり", 180),
+				*entity.ReconstructRecordItem("880e8400-e29b-41d4-a716-446655440003", idStr, "味噌汁", 50),
+				*entity.ReconstructRecordItem("990e8400-e29b-41d4-a716-446655440004", idStr, "焼き鮭", 200),
 			},
 			wantTotal: 430,
 		},
@@ -188,8 +188,8 @@ func TestRecord_TotalCalories(t *testing.T) {
 
 func TestReconstructRecordItem(t *testing.T) {
 	t.Run("DB復元", func(t *testing.T) {
-		idStr := "item-123"
-		recordIDStr := "record-456"
+		idStr := "770e8400-e29b-41d4-a716-446655440002"
+		recordIDStr := "550e8400-e29b-41d4-a716-446655440000"
 		nameStr := "おにぎり"
 		caloriesVal := 180
 

--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -34,6 +34,16 @@ var (
 	ErrInvalidSessionID          = errors.New("invalid session id")
 	ErrSessionExpired            = errors.New("session has expired")
 
+	// UUID errors
+	ErrUUIDRequired      = errors.New("uuid is required")
+	ErrInvalidUUIDFormat = errors.New("invalid uuid format")
+
+	// ID errors
+	ErrInvalidUserID       = errors.New("invalid user id")
+	ErrInvalidRecordID     = errors.New("invalid record id")
+	ErrInvalidRecordItemID = errors.New("invalid record item id")
+	ErrInvalidRecordPfcID  = errors.New("invalid record pfc id")
+
 	// Record Item errors
 	ErrItemNameRequired = errors.New("item name is required")
 

--- a/backend/domain/vo/record_id.go
+++ b/backend/domain/vo/record_id.go
@@ -1,30 +1,44 @@
 package vo
 
 import (
-	"github.com/google/uuid"
+	domainErrors "caltrack/domain/errors"
 )
 
 // RecordID はカロリー記録の識別子を表す値オブジェクト
 type RecordID struct {
-	value string
+	value UUID
 }
 
 // NewRecordID は新しいRecordIDを生成する
 func NewRecordID() RecordID {
-	return RecordID{value: uuid.New().String()}
+	return RecordID{value: NewUUID()}
+}
+
+// ParseRecordID は文字列からRecordIDを生成する
+func ParseRecordID(value string) (RecordID, error) {
+	parsed, err := ParseUUID(value)
+	if err != nil {
+		return RecordID{}, domainErrors.ErrInvalidRecordID
+	}
+	return RecordID{value: parsed}, nil
 }
 
 // ReconstructRecordID はDBからRecordIDを復元する
 func ReconstructRecordID(value string) RecordID {
-	return RecordID{value: value}
+	return RecordID{value: ReconstructUUID(value)}
 }
 
 // String はRecordIDの文字列表現を返す
 func (r RecordID) String() string {
-	return r.value
+	return r.value.String()
+}
+
+// IsZero はRecordIDがゼロ値かを判定する
+func (r RecordID) IsZero() bool {
+	return r.value.IsZero()
 }
 
 // Equals は2つのRecordIDが等しいかを比較する
 func (r RecordID) Equals(other RecordID) bool {
-	return r.value == other.value
+	return r.value.Equals(other.value)
 }

--- a/backend/domain/vo/record_item_id.go
+++ b/backend/domain/vo/record_item_id.go
@@ -1,30 +1,44 @@
 package vo
 
 import (
-	"github.com/google/uuid"
+	domainErrors "caltrack/domain/errors"
 )
 
 // RecordItemID はカロリー記録明細の識別子を表す値オブジェクト
 type RecordItemID struct {
-	value string
+	value UUID
 }
 
 // NewRecordItemID は新しいRecordItemIDを生成する
 func NewRecordItemID() RecordItemID {
-	return RecordItemID{value: uuid.New().String()}
+	return RecordItemID{value: NewUUID()}
+}
+
+// ParseRecordItemID は文字列からRecordItemIDを生成する
+func ParseRecordItemID(value string) (RecordItemID, error) {
+	parsed, err := ParseUUID(value)
+	if err != nil {
+		return RecordItemID{}, domainErrors.ErrInvalidRecordItemID
+	}
+	return RecordItemID{value: parsed}, nil
 }
 
 // ReconstructRecordItemID はDBからRecordItemIDを復元する
 func ReconstructRecordItemID(value string) RecordItemID {
-	return RecordItemID{value: value}
+	return RecordItemID{value: ReconstructUUID(value)}
 }
 
 // String はRecordItemIDの文字列表現を返す
 func (r RecordItemID) String() string {
-	return r.value
+	return r.value.String()
+}
+
+// IsZero はRecordItemIDがゼロ値かを判定する
+func (r RecordItemID) IsZero() bool {
+	return r.value.IsZero()
 }
 
 // Equals は2つのRecordItemIDが等しいかを比較する
 func (r RecordItemID) Equals(other RecordItemID) bool {
-	return r.value == other.value
+	return r.value.Equals(other.value)
 }

--- a/backend/domain/vo/record_pfc_id.go
+++ b/backend/domain/vo/record_pfc_id.go
@@ -1,0 +1,44 @@
+package vo
+
+import (
+	domainErrors "caltrack/domain/errors"
+)
+
+// RecordPfcID はカロリー記録のPFC情報の識別子を表す値オブジェクト
+type RecordPfcID struct {
+	value UUID
+}
+
+// NewRecordPfcID は新しいRecordPfcIDを生成する
+func NewRecordPfcID() RecordPfcID {
+	return RecordPfcID{value: NewUUID()}
+}
+
+// ParseRecordPfcID は文字列からRecordPfcIDを生成する
+func ParseRecordPfcID(value string) (RecordPfcID, error) {
+	parsed, err := ParseUUID(value)
+	if err != nil {
+		return RecordPfcID{}, domainErrors.ErrInvalidRecordPfcID
+	}
+	return RecordPfcID{value: parsed}, nil
+}
+
+// ReconstructRecordPfcID はDBからRecordPfcIDを復元する
+func ReconstructRecordPfcID(value string) RecordPfcID {
+	return RecordPfcID{value: ReconstructUUID(value)}
+}
+
+// String はRecordPfcIDの文字列表現を返す
+func (r RecordPfcID) String() string {
+	return r.value.String()
+}
+
+// IsZero はRecordPfcIDがゼロ値かを判定する
+func (r RecordPfcID) IsZero() bool {
+	return r.value.IsZero()
+}
+
+// Equals は2つのRecordPfcIDが等しいかを比較する
+func (r RecordPfcID) Equals(other RecordPfcID) bool {
+	return r.value.Equals(other.value)
+}

--- a/backend/domain/vo/record_pfc_id_test.go
+++ b/backend/domain/vo/record_pfc_id_test.go
@@ -1,0 +1,162 @@
+package vo_test
+
+import (
+	"testing"
+
+	"caltrack/domain/vo"
+	domainErrors "caltrack/domain/errors"
+
+	"github.com/google/uuid"
+)
+
+func TestNewRecordPfcID(t *testing.T) {
+	t.Run("新しいRecordPfcIDを生成できる", func(t *testing.T) {
+		id := vo.NewRecordPfcID()
+
+		if id.String() == "" {
+			t.Error("NewRecordPfcID() should return non-empty string")
+		}
+		if _, err := uuid.Parse(id.String()); err != nil {
+			t.Errorf("NewRecordPfcID() should return valid UUID, got: %s", id.String())
+		}
+	})
+
+	t.Run("毎回異なるRecordPfcIDを生成する", func(t *testing.T) {
+		id1 := vo.NewRecordPfcID()
+		id2 := vo.NewRecordPfcID()
+
+		if id1.Equals(id2) {
+			t.Error("NewRecordPfcID() should generate different IDs")
+		}
+	})
+}
+
+func TestParseRecordPfcID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{
+			name:    "正常系_有効なUUID",
+			input:   "550e8400-e29b-41d4-a716-446655440000",
+			wantErr: nil,
+		},
+		{
+			name:    "異常系_空文字",
+			input:   "",
+			wantErr: domainErrors.ErrInvalidRecordPfcID,
+		},
+		{
+			name:    "異常系_無効なフォーマット",
+			input:   "invalid-uuid",
+			wantErr: domainErrors.ErrInvalidRecordPfcID,
+		},
+		{
+			name:    "異常系_短すぎる",
+			input:   "550e8400-e29b-41d4",
+			wantErr: domainErrors.ErrInvalidRecordPfcID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vo.ParseRecordPfcID(tt.input)
+
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Errorf("ParseRecordPfcID() error = %v, want %v", err, tt.wantErr)
+				}
+				if !got.IsZero() {
+					t.Error("ParseRecordPfcID() should return zero ID on error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ParseRecordPfcID() unexpected error = %v", err)
+				}
+				if got.String() != tt.input {
+					t.Errorf("ParseRecordPfcID().String() = %v, want %v", got.String(), tt.input)
+				}
+			}
+		})
+	}
+}
+
+func TestReconstructRecordPfcID(t *testing.T) {
+	t.Run("DBからRecordPfcIDを復元できる", func(t *testing.T) {
+		validUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+		got := vo.ReconstructRecordPfcID(validUUID)
+
+		if got.String() != validUUID {
+			t.Errorf("ReconstructRecordPfcID(%q).String() = %v, want %v", validUUID, got.String(), validUUID)
+		}
+	})
+}
+
+func TestRecordPfcID_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		id   vo.RecordPfcID
+		want bool
+	}{
+		{
+			name: "ゼロ値のRecordPfcID",
+			id:   vo.ReconstructRecordPfcID("00000000-0000-0000-0000-000000000000"),
+			want: true,
+		},
+		{
+			name: "有効なRecordPfcID",
+			id:   vo.ReconstructRecordPfcID("550e8400-e29b-41d4-a716-446655440000"),
+			want: false,
+		},
+		{
+			name: "新規生成したRecordPfcID",
+			id:   vo.NewRecordPfcID(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordPfcID_Equals(t *testing.T) {
+	validUUID := "550e8400-e29b-41d4-a716-446655440000"
+	id1 := vo.ReconstructRecordPfcID(validUUID)
+	id2 := vo.ReconstructRecordPfcID(validUUID)
+	id3 := vo.NewRecordPfcID()
+
+	tests := []struct {
+		name string
+		id1  vo.RecordPfcID
+		id2  vo.RecordPfcID
+		want bool
+	}{
+		{
+			name: "同じ値はtrue",
+			id1:  id1,
+			id2:  id2,
+			want: true,
+		},
+		{
+			name: "異なる値はfalse",
+			id1:  id1,
+			id2:  id3,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.id1.Equals(tt.id2); got != tt.want {
+				t.Errorf("Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/domain/vo/user_id.go
+++ b/backend/domain/vo/user_id.go
@@ -1,26 +1,44 @@
 package vo
 
 import (
-	"github.com/google/uuid"
+	domainErrors "caltrack/domain/errors"
 )
 
+// UserID はユーザーの識別子を表す値オブジェクト
 type UserID struct {
-	value string
+	value UUID
 }
 
+// NewUserID は新しいUserIDを生成する
 func NewUserID() UserID {
-	return UserID{value: uuid.New().String()}
+	return UserID{value: NewUUID()}
+}
+
+// ParseUserID は文字列からUserIDを生成する
+func ParseUserID(value string) (UserID, error) {
+	parsed, err := ParseUUID(value)
+	if err != nil {
+		return UserID{}, domainErrors.ErrInvalidUserID
+	}
+	return UserID{value: parsed}, nil
 }
 
 // ReconstructUserID はDBからUserIDを復元する
 func ReconstructUserID(value string) UserID {
-	return UserID{value: value}
+	return UserID{value: ReconstructUUID(value)}
 }
 
+// String はUserIDの文字列表現を返す
 func (u UserID) String() string {
-	return u.value
+	return u.value.String()
 }
 
+// IsZero はUserIDがゼロ値かを判定する
+func (u UserID) IsZero() bool {
+	return u.value.IsZero()
+}
+
+// Equals は2つのUserIDが等しいかを比較する
 func (u UserID) Equals(other UserID) bool {
-	return u.value == other.value
+	return u.value.Equals(other.value)
 }

--- a/backend/domain/vo/uuid.go
+++ b/backend/domain/vo/uuid.go
@@ -1,0 +1,49 @@
+package vo
+
+import (
+	"github.com/google/uuid"
+	domainErrors "caltrack/domain/errors"
+)
+
+// UUID はUUIDを表す値オブジェクト
+type UUID struct {
+	value uuid.UUID
+}
+
+// NewUUID は新しいUUIDを生成する
+func NewUUID() UUID {
+	return UUID{value: uuid.New()}
+}
+
+// ParseUUID は文字列からUUIDを生成する
+func ParseUUID(value string) (UUID, error) {
+	if value == "" {
+		return UUID{}, domainErrors.ErrUUIDRequired
+	}
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return UUID{}, domainErrors.ErrInvalidUUIDFormat
+	}
+	return UUID{value: parsed}, nil
+}
+
+// ReconstructUUID はDBからUUIDを復元する（バリデーションなし）
+func ReconstructUUID(value string) UUID {
+	parsed, _ := uuid.Parse(value)
+	return UUID{value: parsed}
+}
+
+// String はUUIDの文字列表現を返す
+func (u UUID) String() string {
+	return u.value.String()
+}
+
+// IsZero はUUIDがゼロ値かを判定する
+func (u UUID) IsZero() bool {
+	return u.value == uuid.Nil
+}
+
+// Equals は2つのUUIDが等しいかを比較する
+func (u UUID) Equals(other UUID) bool {
+	return u.value == other.value
+}

--- a/backend/domain/vo/uuid_test.go
+++ b/backend/domain/vo/uuid_test.go
@@ -1,0 +1,174 @@
+package vo_test
+
+import (
+	"testing"
+
+	"caltrack/domain/vo"
+	domainErrors "caltrack/domain/errors"
+
+	"github.com/google/uuid"
+)
+
+func TestNewUUID(t *testing.T) {
+	t.Run("新しいUUIDを生成できる", func(t *testing.T) {
+		u := vo.NewUUID()
+
+		if u.String() == "" {
+			t.Error("NewUUID() should return non-empty string")
+		}
+		if _, err := uuid.Parse(u.String()); err != nil {
+			t.Errorf("NewUUID() should return valid UUID, got: %s", u.String())
+		}
+	})
+
+	t.Run("毎回異なるUUIDを生成する", func(t *testing.T) {
+		u1 := vo.NewUUID()
+		u2 := vo.NewUUID()
+
+		if u1.Equals(u2) {
+			t.Error("NewUUID() should generate different UUIDs")
+		}
+	})
+}
+
+func TestParseUUID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr error
+	}{
+		{
+			name:    "正常系_有効なUUID",
+			input:   "550e8400-e29b-41d4-a716-446655440000",
+			wantErr: nil,
+		},
+		{
+			name:    "異常系_空文字",
+			input:   "",
+			wantErr: domainErrors.ErrUUIDRequired,
+		},
+		{
+			name:    "異常系_無効なフォーマット",
+			input:   "invalid-uuid",
+			wantErr: domainErrors.ErrInvalidUUIDFormat,
+		},
+		{
+			name:    "異常系_短すぎる",
+			input:   "550e8400-e29b-41d4",
+			wantErr: domainErrors.ErrInvalidUUIDFormat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := vo.ParseUUID(tt.input)
+
+			if tt.wantErr != nil {
+				if err != tt.wantErr {
+					t.Errorf("ParseUUID() error = %v, want %v", err, tt.wantErr)
+				}
+				if !got.IsZero() {
+					t.Error("ParseUUID() should return zero UUID on error")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("ParseUUID() unexpected error = %v", err)
+				}
+				if got.String() != tt.input {
+					t.Errorf("ParseUUID().String() = %v, want %v", got.String(), tt.input)
+				}
+			}
+		})
+	}
+}
+
+func TestReconstructUUID(t *testing.T) {
+	t.Run("正常系_有効なUUID", func(t *testing.T) {
+		validUUID := "550e8400-e29b-41d4-a716-446655440000"
+
+		got := vo.ReconstructUUID(validUUID)
+
+		if got.String() != validUUID {
+			t.Errorf("ReconstructUUID(%q).String() = %v, want %v", validUUID, got.String(), validUUID)
+		}
+	})
+
+	t.Run("DB復元時はエラーにならない", func(t *testing.T) {
+		// DB復元はバリデーションしないのでエラーにならない
+		invalidUUID := "invalid-uuid"
+
+		got := vo.ReconstructUUID(invalidUUID)
+
+		// 無効なUUIDはゼロ値になる
+		if !got.IsZero() {
+			t.Error("ReconstructUUID() with invalid UUID should return zero UUID")
+		}
+	})
+}
+
+func TestUUID_IsZero(t *testing.T) {
+	tests := []struct {
+		name string
+		uuid vo.UUID
+		want bool
+	}{
+		{
+			name: "ゼロ値のUUID",
+			uuid: vo.ReconstructUUID("00000000-0000-0000-0000-000000000000"),
+			want: true,
+		},
+		{
+			name: "有効なUUID",
+			uuid: vo.ReconstructUUID("550e8400-e29b-41d4-a716-446655440000"),
+			want: false,
+		},
+		{
+			name: "新規生成したUUID",
+			uuid: vo.NewUUID(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.uuid.IsZero(); got != tt.want {
+				t.Errorf("IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUUID_Equals(t *testing.T) {
+	validUUID := "550e8400-e29b-41d4-a716-446655440000"
+	u1 := vo.ReconstructUUID(validUUID)
+	u2 := vo.ReconstructUUID(validUUID)
+	u3 := vo.NewUUID()
+
+	tests := []struct {
+		name string
+		u1   vo.UUID
+		u2   vo.UUID
+		want bool
+	}{
+		{
+			name: "同じ値はtrue",
+			u1:   u1,
+			u2:   u2,
+			want: true,
+		},
+		{
+			name: "異なる値はfalse",
+			u1:   u1,
+			u2:   u3,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.u1.Equals(tt.u2); got != tt.want {
+				t.Errorf("Equals() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- 共通UUID VOを追加してID VOの重複コードを削減
- UserID, RecordID, RecordItemIDにParseメソッドとIsZeroメソッドを追加
- RecordPfcID VOを新規追加
- RecordPfc Entityを新規追加（PFC値を記録する）
- domain/errorsにUUID関連エラーとID関連エラーを追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass (311 tests)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)