### PR TITLE
feat(handler): PFC分析アドバイス取得エンドポイントを追加

### DIFF
--- a/backend/domain/vo/record_pfc_id_test.go
+++ b/backend/domain/vo/record_pfc_id_test.go
@@ -3,8 +3,8 @@ package vo_test
 import (
 	"testing"
 
-	"caltrack/domain/vo"
 	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
 
 	"github.com/google/uuid"
 )

--- a/backend/domain/vo/uuid.go
+++ b/backend/domain/vo/uuid.go
@@ -1,8 +1,8 @@
 package vo
 
 import (
-	"github.com/google/uuid"
 	domainErrors "caltrack/domain/errors"
+	"github.com/google/uuid"
 )
 
 // UUID はUUIDを表す値オブジェクト

--- a/backend/domain/vo/uuid_test.go
+++ b/backend/domain/vo/uuid_test.go
@@ -3,8 +3,8 @@ package vo_test
 import (
 	"testing"
 
-	"caltrack/domain/vo"
 	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
 
 	"github.com/google/uuid"
 )

--- a/backend/handler/nutrition/dto/response.go
+++ b/backend/handler/nutrition/dto/response.go
@@ -1,0 +1,17 @@
+package dto
+
+import (
+	"caltrack/usecase/service"
+)
+
+// AdviceResponse は栄養アドバイスレスポンスDTO
+type AdviceResponse struct {
+	Advice string `json:"advice"`
+}
+
+// NewAdviceResponse はUsecaseの出力からレスポンスDTOを生成する
+func NewAdviceResponse(output *service.NutritionAdviceOutput) AdviceResponse {
+	return AdviceResponse{
+		Advice: output.Advice,
+	}
+}

--- a/backend/handler/nutrition/handler.go
+++ b/backend/handler/nutrition/handler.go
@@ -1,0 +1,51 @@
+package nutrition
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/vo"
+	"caltrack/handler/common"
+	"caltrack/handler/nutrition/dto"
+	"caltrack/usecase"
+)
+
+// NutritionHandler は栄養分析関連のHTTPハンドラ
+type NutritionHandler struct {
+	usecase *usecase.NutritionUsecase
+}
+
+// NewNutritionHandler は NutritionHandler のインスタンスを生成する
+func NewNutritionHandler(uc *usecase.NutritionUsecase) *NutritionHandler {
+	return &NutritionHandler{usecase: uc}
+}
+
+// GetAdvice は栄養アドバイスを取得する
+func (h *NutritionHandler) GetAdvice(c *gin.Context) {
+	// コンテキストからユーザーIDを取得
+	userIDStr, exists := c.Get("userID")
+	if !exists {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeUnauthorized, "User not authenticated", nil)
+		return
+	}
+
+	// UserID VOに変換
+	userID := vo.ReconstructUserID(userIDStr.(string))
+
+	// Usecase実行
+	output, err := h.usecase.GetAdvice(c.Request.Context(), userID)
+	if err != nil {
+		if errors.Is(err, domainErrors.ErrUserNotFound) {
+			common.RespondError(c, http.StatusNotFound, common.CodeNotFound, "User not found", nil)
+			return
+		}
+		common.RespondError(c, http.StatusInternalServerError, common.CodeInternalError, "Internal server error", err)
+		return
+	}
+
+	// 成功レスポンス
+	c.JSON(http.StatusOK, dto.NewAdviceResponse(output))
+}

--- a/backend/handler/nutrition/handler_test.go
+++ b/backend/handler/nutrition/handler_test.go
@@ -1,0 +1,252 @@
+package nutrition_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/repository"
+	"caltrack/domain/vo"
+	"caltrack/handler/common"
+	"caltrack/handler/nutrition"
+	"caltrack/handler/nutrition/dto"
+	"caltrack/usecase"
+	"caltrack/usecase/service"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// mockUserRepository はUserRepositoryのモック実装
+type mockUserRepository struct {
+	findByID func(ctx context.Context, id vo.UserID) (*entity.User, error)
+}
+
+func (m *mockUserRepository) Save(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
+func (m *mockUserRepository) FindByEmail(ctx context.Context, email vo.Email) (*entity.User, error) {
+	return nil, nil
+}
+
+func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
+	return false, nil
+}
+
+func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entity.User, error) {
+	if m.findByID != nil {
+		return m.findByID(ctx, id)
+	}
+	return nil, nil
+}
+
+// mockRecordRepository はRecordRepositoryのモック実装
+type mockRecordRepository struct{}
+
+func (m *mockRecordRepository) Save(ctx context.Context, record *entity.Record) error {
+	return nil
+}
+
+func (m *mockRecordRepository) FindByUserIDAndDateRange(ctx context.Context, userID vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
+	return nil, nil
+}
+
+func (m *mockRecordRepository) GetDailyCalories(ctx context.Context, userID vo.UserID, period vo.StatisticsPeriod) ([]repository.DailyCalories, error) {
+	return nil, nil
+}
+
+// mockRecordPfcRepository はRecordPfcRepositoryのモック実装
+type mockRecordPfcRepository struct{}
+
+func (m *mockRecordPfcRepository) Save(ctx context.Context, recordPfc *entity.RecordPfc) error {
+	return nil
+}
+
+func (m *mockRecordPfcRepository) FindByRecordID(ctx context.Context, recordID vo.RecordID) (*entity.RecordPfc, error) {
+	return nil, nil
+}
+
+func (m *mockRecordPfcRepository) FindByRecordIDs(ctx context.Context, recordIDs []vo.RecordID) ([]*entity.RecordPfc, error) {
+	return nil, nil
+}
+
+// mockPfcAnalyzer はPfcAnalyzerのモック実装
+type mockPfcAnalyzer struct {
+	analyze func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error)
+}
+
+func (m *mockPfcAnalyzer) Analyze(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
+	if m.analyze != nil {
+		return m.analyze(ctx, config, input)
+	}
+	return &service.NutritionAdviceOutput{Advice: "モックアドバイス"}, nil
+}
+
+// setupHandler はテスト用のハンドラをセットアップする
+func setupHandler(userRepo repository.UserRepository, analyzer service.PfcAnalyzer) *nutrition.NutritionHandler {
+	recordRepo := &mockRecordRepository{}
+	recordPfcRepo := &mockRecordPfcRepository{}
+	uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, analyzer)
+	return nutrition.NewNutritionHandler(uc)
+}
+
+func TestNutritionHandler_GetAdvice(t *testing.T) {
+	t.Run("正常系_アドバイス取得成功", func(t *testing.T) {
+		userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+		birthDate := time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)
+		now := time.Now()
+
+		userRepo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return entity.ReconstructUser(
+					userIDStr,
+					"test@example.com",
+					"$2a$10$dummy_hash",
+					"テストユーザー",
+					70.0,
+					170.0,
+					birthDate,
+					"male",
+					"moderate",
+					now,
+					now,
+				)
+			},
+		}
+
+		analyzer := &mockPfcAnalyzer{
+			analyze: func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
+				return &service.NutritionAdviceOutput{
+					Advice: "バランスの良い食事を心がけましょう。",
+				}, nil
+			},
+		}
+
+		handler := setupHandler(userRepo, analyzer)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/nutrition/advice", nil)
+		c.Set("userID", userIDStr)
+
+		handler.GetAdvice(c)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d, body = %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		var resp dto.AdviceResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Advice == "" {
+			t.Error("advice should not be empty")
+		}
+
+		expectedAdvice := "バランスの良い食事を心がけましょう。"
+		if resp.Advice != expectedAdvice {
+			t.Errorf("advice = %s, want %s", resp.Advice, expectedAdvice)
+		}
+	})
+
+	t.Run("異常系_未認証（userIDがない）", func(t *testing.T) {
+		userRepo := &mockUserRepository{}
+		analyzer := &mockPfcAnalyzer{}
+		handler := setupHandler(userRepo, analyzer)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/nutrition/advice", nil)
+		// userIDを設定しない
+
+		handler.GetAdvice(c)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeUnauthorized {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeUnauthorized)
+		}
+	})
+
+	t.Run("異常系_ユーザーが見つからない", func(t *testing.T) {
+		userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+
+		userRepo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return nil, domainErrors.ErrUserNotFound
+			},
+		}
+		analyzer := &mockPfcAnalyzer{}
+		handler := setupHandler(userRepo, analyzer)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/nutrition/advice", nil)
+		c.Set("userID", userIDStr)
+
+		handler.GetAdvice(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeNotFound {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeNotFound)
+		}
+	})
+
+	t.Run("異常系_Usecaseエラー", func(t *testing.T) {
+		userIDStr := "550e8400-e29b-41d4-a716-446655440000"
+
+		userRepo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return nil, errors.New("database connection error")
+			},
+		}
+		analyzer := &mockPfcAnalyzer{}
+		handler := setupHandler(userRepo, analyzer)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodGet, "/api/v1/nutrition/advice", nil)
+		c.Set("userID", userIDStr)
+
+		handler.GetAdvice(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+		}
+
+		var resp common.ErrorResponse
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+
+		if resp.Code != common.CodeInternalError {
+			t.Errorf("code = %s, want %s", resp.Code, common.CodeInternalError)
+		}
+	})
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -11,6 +11,7 @@ import (
 	"caltrack/handler/analyze"
 	"caltrack/handler/auth"
 	"caltrack/handler/middleware"
+	"caltrack/handler/nutrition"
 	"caltrack/handler/record"
 	"caltrack/handler/user"
 	gormPersistence "caltrack/infrastructure/persistence/gorm"
@@ -51,20 +52,21 @@ func main() {
 
 	// DI - Service
 	imageAnalyzer := infraService.NewGeminiImageAnalyzer(config.GeminiClient)
-	// pfcAnalyzer := infraService.NewGeminiPfcAnalyzer(config.GeminiClient)
+	pfcAnalyzer := infraService.NewGeminiPfcAnalyzer(config.GeminiClient)
 
 	// DI - Usecase
 	userUsecase := usecase.NewUserUsecase(userRepo, txManager)
 	authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
 	recordUsecase := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, txManager)
 	analyzeUsecase := usecase.NewAnalyzeUsecase(imageAnalyzer)
-	// nutritionUsecase := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, pfcAnalyzer)
+	nutritionUsecase := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, pfcAnalyzer)
 
 	// DI - Handler
 	userHandler := user.NewUserHandler(userUsecase)
 	authHandler := auth.NewAuthHandler(authUsecase)
 	recordHandler := record.NewRecordHandler(recordUsecase)
 	analyzeHandler := analyze.NewAnalyzeHandler(analyzeUsecase)
+	nutritionHandler := nutrition.NewNutritionHandler(nutritionUsecase)
 
 	// Setup router
 	r := gin.Default()
@@ -108,6 +110,7 @@ func main() {
 		authenticated.GET("/records/today", recordHandler.GetToday)
 		authenticated.GET("/statistics", recordHandler.GetStatistics)
 		authenticated.POST("/analyze-image", analyzeHandler.AnalyzeImage)
+		authenticated.GET("/nutrition/advice", nutritionHandler.GetAdvice)
 	}
 
 	// Start server


### PR DESCRIPTION
## Summary
- handler/nutrition/dto/response.go: AdviceResponse DTO追加
- handler/nutrition/handler.go: NutritionHandler実装（GetAdvice）
- handler/nutrition/handler_test.go: ハンドラーテスト追加（4テストケース）
- main.go: nutrition handlerのDI・ルーティング追加（GET /api/v1/nutrition/advice）
- domain/vo: UUID関連の軽微な修正

## Test plan
- [x] Build: Pass
- [x] Test: Pass (4 tests)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)