### PR TITLE
feat(nutrition): AIアドバイスのDBキャッシュ機能とUI改善

### DIFF
--- a/backend/domain/entity/advice_cache.go
+++ b/backend/domain/entity/advice_cache.go
@@ -1,0 +1,46 @@
+package entity
+
+import (
+	"time"
+
+	"caltrack/domain/vo"
+)
+
+// AdviceCache はAIアドバイスのキャッシュを表すEntity
+type AdviceCache struct {
+	id        vo.AdviceCacheID
+	userID    vo.UserID
+	cacheDate time.Time
+	advice    string
+	createdAt time.Time
+}
+
+// NewAdviceCache は新しいAdviceCacheを生成する
+func NewAdviceCache(userID vo.UserID, cacheDate time.Time, advice string) *AdviceCache {
+	normalizedDate := time.Date(cacheDate.Year(), cacheDate.Month(), cacheDate.Day(), 0, 0, 0, 0, cacheDate.Location())
+
+	return &AdviceCache{
+		id:        vo.NewAdviceCacheID(),
+		userID:    userID,
+		cacheDate: normalizedDate,
+		advice:    advice,
+		createdAt: time.Now(),
+	}
+}
+
+// ReconstructAdviceCache はDBからAdviceCacheを復元する
+func ReconstructAdviceCache(idStr, userIDStr string, cacheDate time.Time, advice string, createdAt time.Time) *AdviceCache {
+	return &AdviceCache{
+		id:        vo.ReconstructAdviceCacheID(idStr),
+		userID:    vo.ReconstructUserID(userIDStr),
+		cacheDate: cacheDate,
+		advice:    advice,
+		createdAt: createdAt,
+	}
+}
+
+func (a *AdviceCache) ID() vo.AdviceCacheID { return a.id }
+func (a *AdviceCache) UserID() vo.UserID    { return a.userID }
+func (a *AdviceCache) CacheDate() time.Time { return a.cacheDate }
+func (a *AdviceCache) Advice() string       { return a.advice }
+func (a *AdviceCache) CreatedAt() time.Time { return a.createdAt }

--- a/backend/domain/errors/errors.go
+++ b/backend/domain/errors/errors.go
@@ -39,10 +39,11 @@ var (
 	ErrInvalidUUIDFormat = errors.New("invalid uuid format")
 
 	// ID errors
-	ErrInvalidUserID       = errors.New("invalid user id")
-	ErrInvalidRecordID     = errors.New("invalid record id")
-	ErrInvalidRecordItemID = errors.New("invalid record item id")
-	ErrInvalidRecordPfcID  = errors.New("invalid record pfc id")
+	ErrInvalidUserID        = errors.New("invalid user id")
+	ErrInvalidRecordID      = errors.New("invalid record id")
+	ErrInvalidRecordItemID  = errors.New("invalid record item id")
+	ErrInvalidRecordPfcID   = errors.New("invalid record pfc id")
+	ErrInvalidAdviceCacheID = errors.New("invalid advice cache id")
 
 	// Record Item errors
 	ErrItemNameRequired = errors.New("item name is required")

--- a/backend/domain/repository/advice_cache_repository.go
+++ b/backend/domain/repository/advice_cache_repository.go
@@ -1,0 +1,16 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"caltrack/domain/entity"
+	"caltrack/domain/vo"
+)
+
+// AdviceCacheRepository はアドバイスキャッシュの永続化を担当するリポジトリインターフェース
+type AdviceCacheRepository interface {
+	Save(ctx context.Context, cache *entity.AdviceCache) error
+	FindByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) (*entity.AdviceCache, error)
+	DeleteByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) error
+}

--- a/backend/domain/vo/advice_cache_id.go
+++ b/backend/domain/vo/advice_cache_id.go
@@ -1,0 +1,44 @@
+package vo
+
+import (
+	domainErrors "caltrack/domain/errors"
+)
+
+// AdviceCacheID はアドバイスキャッシュの識別子を表す値オブジェクト
+type AdviceCacheID struct {
+	value UUID
+}
+
+// NewAdviceCacheID は新しいAdviceCacheIDを生成する
+func NewAdviceCacheID() AdviceCacheID {
+	return AdviceCacheID{value: NewUUID()}
+}
+
+// ParseAdviceCacheID は文字列からAdviceCacheIDを生成する
+func ParseAdviceCacheID(value string) (AdviceCacheID, error) {
+	parsed, err := ParseUUID(value)
+	if err != nil {
+		return AdviceCacheID{}, domainErrors.ErrInvalidAdviceCacheID
+	}
+	return AdviceCacheID{value: parsed}, nil
+}
+
+// ReconstructAdviceCacheID はDBからAdviceCacheIDを復元する
+func ReconstructAdviceCacheID(value string) AdviceCacheID {
+	return AdviceCacheID{value: ReconstructUUID(value)}
+}
+
+// String はAdviceCacheIDの文字列表現を返す
+func (a AdviceCacheID) String() string {
+	return a.value.String()
+}
+
+// IsZero はAdviceCacheIDがゼロ値かを判定する
+func (a AdviceCacheID) IsZero() bool {
+	return a.value.IsZero()
+}
+
+// Equals は2つのAdviceCacheIDが等しいかを比較する
+func (a AdviceCacheID) Equals(other AdviceCacheID) bool {
+	return a.value.Equals(other.value)
+}

--- a/backend/handler/record/handler_test.go
+++ b/backend/handler/record/handler_test.go
@@ -110,20 +110,37 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return nil, nil
 }
 
+// mockAdviceCacheRepository はAdviceCacheRepositoryのモック実装
+type mockAdviceCacheRepository struct{}
+
+func (m *mockAdviceCacheRepository) Save(ctx context.Context, cache *entity.AdviceCache) error {
+	return nil
+}
+
+func (m *mockAdviceCacheRepository) FindByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) (*entity.AdviceCache, error) {
+	return nil, nil
+}
+
+func (m *mockAdviceCacheRepository) DeleteByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) error {
+	return nil
+}
+
 // setupHandler はテスト用のハンドラをセットアップする
 func setupHandler(recordRepo repository.RecordRepository) *record.RecordHandler {
 	recordPfcRepo := &mockRecordPfcRepository{}
 	userRepo := &mockUserRepository{}
+	adviceCacheRepo := &mockAdviceCacheRepository{}
 	txManager := &mockTransactionManager{}
-	uc := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, txManager)
+	uc := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, adviceCacheRepo, txManager)
 	return record.NewRecordHandler(uc)
 }
 
 // setupHandlerWithUserRepo はUserRepositoryを指定してテスト用のハンドラをセットアップする
 func setupHandlerWithUserRepo(recordRepo repository.RecordRepository, userRepo repository.UserRepository) *record.RecordHandler {
 	recordPfcRepo := &mockRecordPfcRepository{}
+	adviceCacheRepo := &mockAdviceCacheRepository{}
 	txManager := &mockTransactionManager{}
-	uc := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, txManager)
+	uc := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, adviceCacheRepo, txManager)
 	return record.NewRecordHandler(uc)
 }
 

--- a/backend/infrastructure/persistence/gorm/advice_cache_repository.go
+++ b/backend/infrastructure/persistence/gorm/advice_cache_repository.go
@@ -1,0 +1,72 @@
+package gorm
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"gorm.io/gorm"
+
+	"caltrack/domain/entity"
+	"caltrack/domain/vo"
+	"caltrack/infrastructure/persistence/gorm/model"
+)
+
+type GormAdviceCacheRepository struct {
+	db *gorm.DB
+}
+
+func NewGormAdviceCacheRepository(db *gorm.DB) *GormAdviceCacheRepository {
+	return &GormAdviceCacheRepository{db: db}
+}
+
+func (r *GormAdviceCacheRepository) Save(ctx context.Context, cache *entity.AdviceCache) error {
+	tx := GetTx(ctx, r.db)
+	cacheModel := toAdviceCacheModel(cache)
+	if err := tx.Create(&cacheModel).Error; err != nil {
+		logError("Save", err, "advice_cache_id", cache.ID().String())
+		return err
+	}
+	return nil
+}
+
+func (r *GormAdviceCacheRepository) FindByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) (*entity.AdviceCache, error) {
+	tx := GetTx(ctx, r.db)
+	normalizedDate := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
+
+	var m model.AdviceCache
+	err := tx.Where("user_id = ? AND cache_date = ?", userID.String(), normalizedDate).First(&m).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		logError("FindByUserIDAndDate", err, "user_id", userID.String())
+		return nil, err
+	}
+	return toAdviceCacheEntity(&m), nil
+}
+
+func (r *GormAdviceCacheRepository) DeleteByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) error {
+	tx := GetTx(ctx, r.db)
+	normalizedDate := time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, date.Location())
+
+	if err := tx.Where("user_id = ? AND cache_date = ?", userID.String(), normalizedDate).Delete(&model.AdviceCache{}).Error; err != nil {
+		logError("DeleteByUserIDAndDate", err, "user_id", userID.String())
+		return err
+	}
+	return nil
+}
+
+func toAdviceCacheModel(cache *entity.AdviceCache) model.AdviceCache {
+	return model.AdviceCache{
+		ID:        cache.ID().String(),
+		UserID:    cache.UserID().String(),
+		CacheDate: cache.CacheDate(),
+		Advice:    cache.Advice(),
+		CreatedAt: cache.CreatedAt(),
+	}
+}
+
+func toAdviceCacheEntity(m *model.AdviceCache) *entity.AdviceCache {
+	return entity.ReconstructAdviceCache(m.ID, m.UserID, m.CacheDate, m.Advice, m.CreatedAt)
+}

--- a/backend/infrastructure/persistence/gorm/model/advice_cache.go
+++ b/backend/infrastructure/persistence/gorm/model/advice_cache.go
@@ -1,0 +1,16 @@
+package model
+
+import "time"
+
+// AdviceCache はAIアドバイスキャッシュを保持するGORMモデル
+type AdviceCache struct {
+	ID        string    `gorm:"primaryKey;size:36"`
+	UserID    string    `gorm:"size:36;not null;index:uk_user_date,unique"`
+	CacheDate time.Time `gorm:"type:date;not null;index:uk_user_date,unique"`
+	Advice    string    `gorm:"type:text;not null"`
+	CreatedAt time.Time `gorm:"not null"`
+}
+
+func (AdviceCache) TableName() string {
+	return "advice_caches"
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -48,6 +48,7 @@ func main() {
 	sessionRepo := gormPersistence.NewGormSessionRepository(config.DB)
 	recordRepo := gormPersistence.NewGormRecordRepository(config.DB)
 	recordPfcRepo := gormPersistence.NewGormRecordPfcRepository(config.DB)
+	adviceCacheRepo := gormPersistence.NewGormAdviceCacheRepository(config.DB)
 	txManager := gormPersistence.NewGormTransactionManager(config.DB)
 
 	// DI - Service
@@ -57,9 +58,9 @@ func main() {
 	// DI - Usecase
 	userUsecase := usecase.NewUserUsecase(userRepo, txManager)
 	authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
-	recordUsecase := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, txManager)
+	recordUsecase := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, adviceCacheRepo, txManager)
 	analyzeUsecase := usecase.NewAnalyzeUsecase(imageAnalyzer)
-	nutritionUsecase := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, pfcAnalyzer)
+	nutritionUsecase := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, pfcAnalyzer)
 
 	// DI - Handler
 	userHandler := user.NewUserHandler(userUsecase)

--- a/backend/migrations/005_create_advice_caches.sql
+++ b/backend/migrations/005_create_advice_caches.sql
@@ -1,0 +1,13 @@
+-- +migrate Up
+CREATE TABLE advice_caches (
+    id VARCHAR(36) PRIMARY KEY,
+    user_id VARCHAR(36) NOT NULL,
+    cache_date DATE NOT NULL,
+    advice TEXT NOT NULL,
+    created_at DATETIME NOT NULL,
+    UNIQUE KEY uk_user_date (user_id, cache_date),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- +migrate Down
+DROP TABLE advice_caches;

--- a/frontend/src/features/common/hooks/useRequest.ts
+++ b/frontend/src/features/common/hooks/useRequest.ts
@@ -18,6 +18,7 @@ type UseRequestGetReturn<T> = {
   data: T | undefined;
   error: ApiErrorResponse | undefined;
   isLoading: boolean;
+  isValidating: boolean;
   mutate: () => Promise<T | undefined>;
 };
 
@@ -33,7 +34,7 @@ type UseRequestMutationReturn<T, D> = {
  * GETリクエスト用フック
  */
 export function useRequestGet<T>(url: string | null): UseRequestGetReturn<T> {
-  const { data, error, isLoading, mutate: swrMutate } = useSWR<T, ApiErrorResponse>(
+  const { data, error, isLoading, isValidating, mutate: swrMutate } = useSWR<T, ApiErrorResponse>(
     url,
     fetcher,
     { revalidateOnFocus: false }
@@ -42,6 +43,7 @@ export function useRequestGet<T>(url: string | null): UseRequestGetReturn<T> {
     data,
     error,
     isLoading,
+    isValidating,
     mutate: async () => swrMutate(),
   };
 }

--- a/frontend/src/features/nutrition/components/NutritionAdviceCard.test.tsx
+++ b/frontend/src/features/nutrition/components/NutritionAdviceCard.test.tsx
@@ -15,7 +15,7 @@ describe("NutritionAdviceCard", () => {
       />
     );
 
-    expect(screen.getByText("今日のアドバイス")).toBeInTheDocument();
+    expect(screen.getByText("AIによるアドバイス")).toBeInTheDocument();
     expect(
       screen.getByText("タンパク質が不足しています。鶏肉や卵を食べましょう。")
     ).toBeInTheDocument();
@@ -29,6 +29,23 @@ describe("NutritionAdviceCard", () => {
     // Skeletonコンポーネントが存在することを確認
     const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
     expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("ローディング中は前の情報が表示されない", () => {
+    const { container } = render(
+      <NutritionAdviceCard
+        advice="前回のアドバイス"
+        isLoading={true}
+        error={null}
+      />
+    );
+
+    // スケルトンが表示される
+    const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    // 前の情報は表示されない
+    expect(screen.queryByText("前回のアドバイス")).not.toBeInTheDocument();
   });
 
   it("エラー時はエラーメッセージが表示される", () => {

--- a/frontend/src/features/nutrition/components/NutritionAdviceCard.tsx
+++ b/frontend/src/features/nutrition/components/NutritionAdviceCard.tsx
@@ -21,7 +21,7 @@ export function NutritionAdviceCard({
   error,
 }: NutritionAdviceCardProps) {
   // ローディング状態
-  if (isLoading && !advice) {
+  if (isLoading) {
     return (
       <Card className="opacity-0 animate-fade-in-up">
         <CardHeader className="pb-3">
@@ -46,7 +46,7 @@ export function NutritionAdviceCard({
         <CardHeader className="pb-3">
           <CardTitle className="text-lg flex items-center gap-2">
             <span>💡</span>
-            今日のアドバイス
+            AIによるアドバイス
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -65,7 +65,7 @@ export function NutritionAdviceCard({
         <CardHeader className="pb-3">
           <CardTitle className="text-lg flex items-center gap-2">
             <span>💡</span>
-            今日のアドバイス
+            AIによるアドバイス
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -82,7 +82,7 @@ export function NutritionAdviceCard({
       <CardHeader className="pb-3">
         <CardTitle className="text-lg flex items-center gap-2 text-amber-800">
           <span>💡</span>
-          今日のアドバイス
+          AIによるアドバイス
         </CardTitle>
       </CardHeader>
       <CardContent>

--- a/frontend/src/features/nutrition/hooks/useNutritionAdvice.ts
+++ b/frontend/src/features/nutrition/hooks/useNutritionAdvice.ts
@@ -16,8 +16,9 @@ export const ERROR_MESSAGE_FETCH_FAILED = "アドバイスの取得に失敗し�
  * @returns { data, error, isLoading, refetch }
  */
 export function useNutritionAdvice() {
-  const { data, error, isLoading, mutate } =
+  const { data, error, isLoading, isValidating, mutate } =
     useRequestGet<NutritionAdviceResponse>("/api/v1/nutrition/advice");
 
-  return { data, error, isLoading, refetch: mutate };
+  // APIリクエスト中は常にローディング状態として扱う（再検証中も含む）
+  return { data, error, isLoading: isLoading || isValidating, refetch: mutate };
 }


### PR DESCRIPTION
## Summary
- AIアドバイスを同一日内でDBキャッシュし再利用
- 今日の記録がない場合は固定文言を返却（AIリクエストなし）
- 食事記録追加時にキャッシュを無効化
- UIタイトルを「AIによるアドバイス」に変更
- APIリクエスト中は常にスケルトン表示

## Backend変更
- domain層: AdviceCacheID VO、AdviceCache Entity、Repository Interface追加
- infrastructure層: GORMモデル、Repository実装、マイグレーション追加
- usecase層: キャッシュ取得/保存、固定文言返却、Create時キャッシュ無効化ロジック追加
- main.go: AdviceCacheRepository DI追加

## Frontend変更
- useRequest: isValidating追加
- useNutritionAdvice: 再検証中もローディング状態に
- NutritionAdviceCard: タイトル変更、ローディング条件修正

## Test plan
- [x] Backend Build: Pass
- [x] Backend Test: Pass
- [x] Frontend Build: Pass
- [x] Frontend Test: Pass

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)