### PR TITLE
feat(entity): User EntityにUpdateProfileメソッドを追加

### DIFF
--- a/backend/domain/entity/user.go
+++ b/backend/domain/entity/user.go
@@ -243,3 +243,38 @@ func (u *User) CalculateTargetPfc() vo.Pfc {
 
 	return vo.NewPfc(protein, fat, carbs)
 }
+
+// UpdateProfile はニックネーム、身長、体重、活動レベルを更新する。
+// バリデーションエラーはまとめて返す。全て有効な場合のみ状態を変更する。
+func (u *User) UpdateProfile(
+	nicknameStr string,
+	heightVal float64,
+	weightVal float64,
+	activityLevelStr string,
+) []error {
+	var errs []error
+
+	nickname, err := vo.NewNickname(nicknameStr)
+	errs = appendIfErr(errs, err)
+
+	height, err := vo.NewHeight(heightVal)
+	errs = appendIfErr(errs, err)
+
+	weight, err := vo.NewWeight(weightVal)
+	errs = appendIfErr(errs, err)
+
+	activityLevel, err := vo.NewActivityLevel(activityLevelStr)
+	errs = appendIfErr(errs, err)
+
+	if len(errs) > 0 {
+		return errs
+	}
+
+	u.nickname = nickname
+	u.height = height
+	u.weight = weight
+	u.activityLevel = activityLevel
+	u.updatedAt = time.Now()
+
+	return nil
+}


### PR DESCRIPTION
## Summary
- User EntityにUpdateProfileメソッドを追加
- ニックネーム、身長、体重、アクティブレベルの更新に対応
- バリデーションエラー時は状態を変更しない設計

## Test plan
- [x] TestUser_UpdateProfile_Success
- [x] TestUser_UpdateProfile_ValidationErrors
- [x] TestUser_UpdateProfile_PartialErrors

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)