### PR TITLE
feat(usecase): ユーザープロフィール更新Usecaseを追加

### DIFF
--- a/backend/domain/repository/user_repository.go
+++ b/backend/domain/repository/user_repository.go
@@ -14,4 +14,6 @@ type UserRepository interface {
 	// FindByID は指定IDのユーザーを取得する
 	// 存在しない場合はnilとnilを返す
 	FindByID(ctx context.Context, id vo.UserID) (*entity.User, error)
+	// Update は既存ユーザーを更新する
+	Update(ctx context.Context, user *entity.User) error
 }

--- a/backend/handler/auth/handler_test.go
+++ b/backend/handler/auth/handler_test.go
@@ -50,6 +50,10 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return nil, nil
 }
 
+func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockSessionRepository はSessionRepositoryのモック実装
 type mockSessionRepository struct {
 	save           func(ctx context.Context, session *entity.Session) error

--- a/backend/handler/middleware/auth_test.go
+++ b/backend/handler/middleware/auth_test.go
@@ -49,6 +49,10 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return nil, nil
 }
 
+func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockSessionRepository はSessionRepositoryのモック実装
 type mockSessionRepository struct {
 	save           func(ctx context.Context, session *entity.Session) error

--- a/backend/handler/nutrition/handler_test.go
+++ b/backend/handler/nutrition/handler_test.go
@@ -50,6 +50,10 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return nil, nil
 }
 
+func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockRecordRepository はRecordRepositoryのモック実装
 type mockRecordRepository struct {
 	findByUserIDAndDateRange func(ctx context.Context, userID vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error)

--- a/backend/handler/record/handler_test.go
+++ b/backend/handler/record/handler_test.go
@@ -111,6 +111,10 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return nil, nil
 }
 
+func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockAdviceCacheRepository はAdviceCacheRepositoryのモック実装
 type mockAdviceCacheRepository struct{}
 

--- a/backend/handler/user/handler_test.go
+++ b/backend/handler/user/handler_test.go
@@ -44,6 +44,10 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return nil, nil
 }
 
+func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 type mockTransactionManager struct{}
 
 func (m *mockTransactionManager) Execute(ctx context.Context, fn func(ctx context.Context) error) error {

--- a/backend/infrastructure/persistence/gorm/user_repository.go
+++ b/backend/infrastructure/persistence/gorm/user_repository.go
@@ -70,6 +70,17 @@ func (r *GormUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 	return toUserEntity(&m)
 }
 
+// Update は既存ユーザーを更新する
+func (r *GormUserRepository) Update(ctx context.Context, user *entity.User) error {
+	tx := GetTx(ctx, r.db)
+	m := toUserModel(user)
+	if err := tx.Save(&m).Error; err != nil {
+		logError("Update", err, "user_id", user.ID().String())
+		return err
+	}
+	return nil
+}
+
 func toUserModel(user *entity.User) model.User {
 	return model.User{
 		ID:             user.ID().String(),

--- a/backend/usecase/auth_test.go
+++ b/backend/usecase/auth_test.go
@@ -63,6 +63,10 @@ func (m *mockUserRepositoryForAuth) FindByID(ctx context.Context, id vo.UserID) 
 	return nil, nil
 }
 
+func (m *mockUserRepositoryForAuth) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockTxManager はTransactionManagerのモック実装
 type mockTxManager struct{}
 

--- a/backend/usecase/nutrition_test.go
+++ b/backend/usecase/nutrition_test.go
@@ -78,6 +78,10 @@ func (m *mockNutritionUserRepository) FindByID(ctx context.Context, id vo.UserID
 	return nil, nil
 }
 
+func (m *mockNutritionUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockNutritionRecordRepository はRecordRepositoryのモック実装（Nutrition用）
 type mockNutritionRecordRepository struct {
 	findByUserIDAndDateRange func(ctx context.Context, userID vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error)

--- a/backend/usecase/record_test.go
+++ b/backend/usecase/record_test.go
@@ -91,6 +91,10 @@ func (m *mockRecordUserRepository) FindByID(ctx context.Context, id vo.UserID) (
 	return nil, nil
 }
 
+func (m *mockRecordUserRepository) Update(ctx context.Context, user *entity.User) error {
+	return nil
+}
+
 // mockRecordAdviceCacheRepository はAdviceCacheRepositoryのモック実装
 type mockRecordAdviceCacheRepository struct {
 	deleteByUserIDAndDate func(ctx context.Context, userID vo.UserID, date time.Time) error

--- a/backend/usecase/user.go
+++ b/backend/usecase/user.go
@@ -2,10 +2,13 @@ package usecase
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"caltrack/domain/entity"
 	domainErrors "caltrack/domain/errors"
 	"caltrack/domain/repository"
+	"caltrack/domain/vo"
 )
 
 type UserUsecase struct {
@@ -47,4 +50,58 @@ func (u *UserUsecase) Register(ctx context.Context, user *entity.User) (*entity.
 	}
 
 	return user, nil
+}
+
+// UpdateProfileInput はプロフィール更新の入力を表す
+type UpdateProfileInput struct {
+	Nickname      string
+	Height        float64
+	Weight        float64
+	ActivityLevel string
+}
+
+// UpdateProfile は認証ユーザーのプロフィールを更新する
+func (u *UserUsecase) UpdateProfile(ctx context.Context, userID vo.UserID, input UpdateProfileInput) (*entity.User, error) {
+	var updatedUser *entity.User
+
+	err := u.txManager.Execute(ctx, func(txCtx context.Context) error {
+		user, err := u.userRepo.FindByID(txCtx, userID)
+		if err != nil {
+			logError("UpdateProfile", err, "user_id", userID.String())
+			return err
+		}
+		if user == nil {
+			logWarn("UpdateProfile", "user not found", "user_id", userID.String())
+			return domainErrors.ErrUserNotFound
+		}
+
+		errs := user.UpdateProfile(input.Nickname, input.Height, input.Weight, input.ActivityLevel)
+		if errs != nil {
+			logWarn("UpdateProfile", "validation errors", "user_id", userID.String(), "errors", formatErrors(errs))
+			return errs[0]
+		}
+
+		if err := u.userRepo.Update(txCtx, user); err != nil {
+			logError("UpdateProfile", err, "user_id", userID.String())
+			return err
+		}
+
+		updatedUser = user
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return updatedUser, nil
+}
+
+// formatErrors は複数のエラーをカンマ区切りの文字列に変換する
+func formatErrors(errs []error) string {
+	msgs := make([]string, len(errs))
+	for i, err := range errs {
+		msgs[i] = err.Error()
+	}
+	return fmt.Sprintf("[%s]", strings.Join(msgs, ", "))
 }

--- a/backend/usecase/user_test.go
+++ b/backend/usecase/user_test.go
@@ -16,6 +16,7 @@ type mockUserRepository struct {
 	existsByEmail func(ctx context.Context, email vo.Email) (bool, error)
 	save          func(ctx context.Context, user *entity.User) error
 	findByID      func(ctx context.Context, id vo.UserID) (*entity.User, error)
+	update        func(ctx context.Context, user *entity.User) error
 }
 
 func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
@@ -35,6 +36,13 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 		return m.findByID(ctx, id)
 	}
 	return nil, nil
+}
+
+func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	if m.update != nil {
+		return m.update(ctx, user)
+	}
+	return nil
 }
 
 type mockTransactionManager struct{}
@@ -57,6 +65,27 @@ func validUser(t *testing.T) *entity.User {
 	)
 	if errs != nil {
 		t.Fatalf("failed to create valid user: %v", errs)
+	}
+	return u
+}
+
+func reconstructedUser(t *testing.T) *entity.User {
+	t.Helper()
+	u, err := entity.ReconstructUser(
+		"550e8400-e29b-41d4-a716-446655440000",
+		"test@example.com",
+		"$2a$10$hashedpassword",
+		"oldnick",
+		60.0,
+		165.0,
+		time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+		"male",
+		"sedentary",
+		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatalf("failed to reconstruct user: %v", err)
 	}
 	return u
 }
@@ -141,6 +170,173 @@ func TestUserUsecase_Register(t *testing.T) {
 
 		if !errors.Is(err, saveErr) {
 			t.Errorf("got %v, want saveErr", err)
+		}
+	})
+}
+
+// TestUserUsecase_UpdateProfile はプロフィール更新機能のテスト
+func TestUserUsecase_UpdateProfile(t *testing.T) {
+	t.Run("正常系_プロフィール更新成功", func(t *testing.T) {
+		user := reconstructedUser(t)
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return user, nil
+			},
+			update: func(ctx context.Context, u *entity.User) error {
+				return nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+
+		uc := usecase.NewUserUsecase(repo, txManager)
+		updatedUser, err := uc.UpdateProfile(context.Background(), user.ID(), usecase.UpdateProfileInput{
+			Nickname:      "newnick",
+			Height:        170.0,
+			Weight:        65.0,
+			ActivityLevel: "moderate",
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updatedUser.Nickname().String() != "newnick" {
+			t.Errorf("nickname got %v, want newnick", updatedUser.Nickname().String())
+		}
+		if updatedUser.Height().Cm() != 170.0 {
+			t.Errorf("height got %v, want 170.0", updatedUser.Height().Cm())
+		}
+		if updatedUser.Weight().Kg() != 65.0 {
+			t.Errorf("weight got %v, want 65.0", updatedUser.Weight().Kg())
+		}
+		if updatedUser.ActivityLevel().String() != "moderate" {
+			t.Errorf("activity level got %v, want moderate", updatedUser.ActivityLevel().String())
+		}
+	})
+
+	t.Run("異常系_ユーザーが見つからない", func(t *testing.T) {
+		userID := vo.NewUserID()
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return nil, nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+
+		uc := usecase.NewUserUsecase(repo, txManager)
+		_, err := uc.UpdateProfile(context.Background(), userID, usecase.UpdateProfileInput{
+			Nickname:      "newnick",
+			Height:        170.0,
+			Weight:        65.0,
+			ActivityLevel: "moderate",
+		})
+
+		if err != domainErrors.ErrUserNotFound {
+			t.Errorf("got %v, want ErrUserNotFound", err)
+		}
+	})
+
+	t.Run("異常系_バリデーションエラー", func(t *testing.T) {
+		user := reconstructedUser(t)
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return user, nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+
+		uc := usecase.NewUserUsecase(repo, txManager)
+		_, err := uc.UpdateProfile(context.Background(), user.ID(), usecase.UpdateProfileInput{
+			Nickname:      "", // ニックネームが空
+			Height:        170.0,
+			Weight:        65.0,
+			ActivityLevel: "moderate",
+		})
+
+		if err != domainErrors.ErrNicknameRequired {
+			t.Errorf("got %v, want ErrNicknameRequired", err)
+		}
+	})
+
+	t.Run("異常系_FindByIDリポジトリエラー", func(t *testing.T) {
+		userID := vo.NewUserID()
+		repoErr := errors.New("db error")
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return nil, repoErr
+			},
+		}
+		txManager := &mockTransactionManager{}
+
+		uc := usecase.NewUserUsecase(repo, txManager)
+		_, err := uc.UpdateProfile(context.Background(), userID, usecase.UpdateProfileInput{
+			Nickname:      "newnick",
+			Height:        170.0,
+			Weight:        65.0,
+			ActivityLevel: "moderate",
+		})
+
+		if !errors.Is(err, repoErr) {
+			t.Errorf("got %v, want repoErr", err)
+		}
+	})
+
+	t.Run("異常系_Updateリポジトリエラー", func(t *testing.T) {
+		user := reconstructedUser(t)
+		updateErr := errors.New("update error")
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return user, nil
+			},
+			update: func(ctx context.Context, u *entity.User) error {
+				return updateErr
+			},
+		}
+		txManager := &mockTransactionManager{}
+
+		uc := usecase.NewUserUsecase(repo, txManager)
+		_, err := uc.UpdateProfile(context.Background(), user.ID(), usecase.UpdateProfileInput{
+			Nickname:      "newnick",
+			Height:        170.0,
+			Weight:        65.0,
+			ActivityLevel: "moderate",
+		})
+
+		if !errors.Is(err, updateErr) {
+			t.Errorf("got %v, want updateErr", err)
+		}
+	})
+
+	t.Run("正常系_更新後のEntityが返却される", func(t *testing.T) {
+		user := reconstructedUser(t)
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return user, nil
+			},
+			update: func(ctx context.Context, u *entity.User) error {
+				return nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+
+		uc := usecase.NewUserUsecase(repo, txManager)
+		updatedUser, err := uc.UpdateProfile(context.Background(), user.ID(), usecase.UpdateProfileInput{
+			Nickname:      "updatednick",
+			Height:        180.0,
+			Weight:        75.0,
+			ActivityLevel: "active",
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updatedUser == nil {
+			t.Fatal("updatedUser should not be nil")
+		}
+		if updatedUser.ID().String() != user.ID().String() {
+			t.Errorf("user ID mismatch: got %v, want %v", updatedUser.ID().String(), user.ID().String())
+		}
+		if updatedUser.Nickname().String() != "updatednick" {
+			t.Errorf("nickname got %v, want updatednick", updatedUser.Nickname().String())
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- UserRepository interfaceにUpdateメソッドを追加
- UserUsecaseにUpdateProfileメソッドを追加
- GormUserRepositoryにUpdate実装を追加
- 全テストファイルのmockにUpdateスタブを追加

## Test plan
- [x] 正常系_プロフィール更新成功
- [x] 異常系_ユーザーが見つからない
- [x] 異常系_バリデーションエラー
- [x] 異常系_FindByIDリポジトリエラー
- [x] 異常系_Updateリポジトリエラー
- [x] 正常系_更新後のEntityが返却される

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)