### PR TITLE
feat(handler): ユーザープロフィール更新エンドポイントを追加

### DIFF
--- a/backend/handler/user/dto/request.go
+++ b/backend/handler/user/dto/request.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"caltrack/domain/entity"
+	"caltrack/usecase"
 )
 
 type RegisterUserRequest struct {
@@ -35,4 +36,22 @@ func (r RegisterUserRequest) ToDomain() (*entity.User, error, []error) {
 	)
 
 	return user, nil, errs
+}
+
+// UpdateProfileRequest はプロフィール更新リクエストDTO
+type UpdateProfileRequest struct {
+	Nickname      string  `json:"nickname" example:"NewNickname"`
+	Height        float64 `json:"height" example:"175.0"`
+	Weight        float64 `json:"weight" example:"70.5"`
+	ActivityLevel string  `json:"activityLevel" example:"moderate"`
+}
+
+// ToInput はUsecaseのUpdateProfileInputに変換する
+func (r UpdateProfileRequest) ToInput() usecase.UpdateProfileInput {
+	return usecase.UpdateProfileInput{
+		Nickname:      r.Nickname,
+		Height:        r.Height,
+		Weight:        r.Weight,
+		ActivityLevel: r.ActivityLevel,
+	}
 }

--- a/backend/handler/user/dto/response.go
+++ b/backend/handler/user/dto/response.go
@@ -1,5 +1,29 @@
 package dto
 
+import (
+	"caltrack/domain/entity"
+)
+
 type RegisterUserResponse struct {
 	UserID string `json:"userId" example:"550e8400-e29b-41d4-a716-446655440000"`
+}
+
+// UpdateProfileResponse はプロフィール更新レスポンスDTO
+type UpdateProfileResponse struct {
+	UserID        string  `json:"userId" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Nickname      string  `json:"nickname" example:"NewNickname"`
+	Height        float64 `json:"height" example:"175.0"`
+	Weight        float64 `json:"weight" example:"70.5"`
+	ActivityLevel string  `json:"activityLevel" example:"moderate"`
+}
+
+// NewUpdateProfileResponse はEntityからレスポンスDTOを生成する
+func NewUpdateProfileResponse(user *entity.User) UpdateProfileResponse {
+	return UpdateProfileResponse{
+		UserID:        user.ID().String(),
+		Nickname:      user.Nickname().String(),
+		Height:        user.Height().Cm(),
+		Weight:        user.Weight().Kg(),
+		ActivityLevel: user.ActivityLevel().String(),
+	}
 }

--- a/backend/handler/user/handler_test.go
+++ b/backend/handler/user/handler_test.go
@@ -2,14 +2,18 @@ package user_test
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 
 	"caltrack/domain/entity"
+	domainErrors "caltrack/domain/errors"
 	"caltrack/domain/vo"
 	"caltrack/handler/user"
 	"caltrack/usecase"
@@ -23,6 +27,7 @@ type mockUserRepository struct {
 	existsByEmail func(ctx context.Context, email vo.Email) (bool, error)
 	save          func(ctx context.Context, user *entity.User) error
 	findByID      func(ctx context.Context, id vo.UserID) (*entity.User, error)
+	update        func(ctx context.Context, user *entity.User) error
 }
 
 func (m *mockUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
@@ -45,6 +50,9 @@ func (m *mockUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entit
 }
 
 func (m *mockUserRepository) Update(ctx context.Context, user *entity.User) error {
+	if m.update != nil {
+		return m.update(ctx, user)
+	}
 	return nil
 }
 
@@ -189,6 +197,259 @@ func TestUserHandler_Register(t *testing.T) {
 
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+// createTestUser はテスト用のユーザーを生成するヘルパー関数
+func createTestUser() *entity.User {
+	user, err := entity.ReconstructUser(
+		"550e8400-e29b-41d4-a716-446655440000",
+		"test@example.com",
+		"$2a$10$hashedpassword",
+		"TestUser",
+		70.0,
+		170.0,
+		time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
+		"male",
+		"moderate",
+		time.Now(),
+		time.Now(),
+	)
+	if err != nil {
+		panic(err)
+	}
+	return user
+}
+
+func TestUserHandler_UpdateProfile(t *testing.T) {
+	t.Run("正常系_プロフィール更新成功", func(t *testing.T) {
+		testUser := createTestUser()
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return testUser, nil
+			},
+			update: func(ctx context.Context, user *entity.User) error {
+				return nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `{
+			"nickname": "UpdatedNickname",
+			"height": 175.0,
+			"weight": 72.5,
+			"activityLevel": "active"
+		}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", testUser.ID().String())
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("status = %d, want %d, body: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		var response map[string]interface{}
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatalf("Failed to parse response: %v", err)
+		}
+
+		if response["userId"] != testUser.ID().String() {
+			t.Errorf("userId = %v, want %v", response["userId"], testUser.ID().String())
+		}
+		if response["nickname"] != "UpdatedNickname" {
+			t.Errorf("nickname = %v, want UpdatedNickname", response["nickname"])
+		}
+		if response["height"] != 175.0 {
+			t.Errorf("height = %v, want 175.0", response["height"])
+		}
+		if response["weight"] != 72.5 {
+			t.Errorf("weight = %v, want 72.5", response["weight"])
+		}
+		if response["activityLevel"] != "active" {
+			t.Errorf("activityLevel = %v, want active", response["activityLevel"])
+		}
+	})
+
+	t.Run("異常系_認証なし", func(t *testing.T) {
+		repo := &mockUserRepository{}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `{
+			"nickname": "UpdatedNickname",
+			"height": 175.0,
+			"weight": 72.5,
+			"activityLevel": "active"
+		}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		// userIDをセットしない
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+		}
+	})
+
+	t.Run("異常系_無効なリクエストボディ", func(t *testing.T) {
+		testUser := createTestUser()
+		repo := &mockUserRepository{}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `invalid json`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", testUser.ID().String())
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("異常系_ユーザーが見つからない", func(t *testing.T) {
+		testUser := createTestUser()
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return nil, domainErrors.ErrUserNotFound
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `{
+			"nickname": "UpdatedNickname",
+			"height": 175.0,
+			"weight": 72.5,
+			"activityLevel": "active"
+		}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", testUser.ID().String())
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusNotFound {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+		}
+	})
+
+	t.Run("異常系_バリデーションエラー_ニックネーム空", func(t *testing.T) {
+		testUser := createTestUser()
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return testUser, nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `{
+			"nickname": "",
+			"height": 175.0,
+			"weight": 72.5,
+			"activityLevel": "active"
+		}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", testUser.ID().String())
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("異常系_バリデーションエラー_不正な活動レベル", func(t *testing.T) {
+		testUser := createTestUser()
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return testUser, nil
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `{
+			"nickname": "UpdatedNickname",
+			"height": 175.0,
+			"weight": 72.5,
+			"activityLevel": "invalid"
+		}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", testUser.ID().String())
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	t.Run("異常系_DB更新失敗", func(t *testing.T) {
+		testUser := createTestUser()
+		repo := &mockUserRepository{
+			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
+				return testUser, nil
+			},
+			update: func(ctx context.Context, user *entity.User) error {
+				return errors.New("database error")
+			},
+		}
+		txManager := &mockTransactionManager{}
+		uc := usecase.NewUserUsecase(repo, txManager)
+		handler := user.NewUserHandler(uc)
+
+		reqBody := `{
+			"nickname": "UpdatedNickname",
+			"height": 175.0,
+			"weight": 72.5,
+			"activityLevel": "active"
+		}`
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest(http.MethodPatch, "/api/v1/users/profile", strings.NewReader(reqBody))
+		c.Request.Header.Set("Content-Type", "application/json")
+		c.Set("userID", testUser.ID().String())
+
+		handler.UpdateProfile(c)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusInternalServerError)
 		}
 	})
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -108,6 +108,7 @@ func main() {
 	authenticated := api.Group("")
 	authenticated.Use(middleware.AuthMiddleware(authUsecase))
 	{
+		authenticated.PATCH("/users/profile", userHandler.UpdateProfile)
 		authenticated.POST("/records", recordHandler.Create)
 		authenticated.GET("/records/today", recordHandler.GetToday)
 		authenticated.GET("/statistics", recordHandler.GetStatistics)


### PR DESCRIPTION
## Summary
- PATCH /api/v1/users/profile エンドポイントを追加
- UpdateProfileRequest/Response DTOを追加
- handleErrorにErrUserNotFound・バリデーションエラーのマッピングを追加
- 認証必須グループにルーティング追加

## Test plan
- [x] 正常系_プロフィール更新成功
- [x] 異常系_認証なし
- [x] 異常系_無効なリクエストボディ
- [x] 異常系_ユーザーが見つからない
- [x] 異常系_バリデーションエラー_ニックネーム空
- [x] 異常系_バリデーションエラー_不正な活動レベル
- [x] 異常系_DB更新失敗

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)