### PR TITLE
feat(usecase): ユーザープロフィール取得Usecaseを追加

### DIFF
--- a/backend/usecase/user.go
+++ b/backend/usecase/user.go
@@ -97,6 +97,21 @@ func (u *UserUsecase) UpdateProfile(ctx context.Context, userID vo.UserID, input
 	return updatedUser, nil
 }
 
+// GetProfile は認証ユーザーのプロフィールを取得する
+func (u *UserUsecase) GetProfile(ctx context.Context, userID vo.UserID) (*entity.User, error) {
+	user, err := u.userRepo.FindByID(ctx, userID)
+	if err != nil {
+		logError("GetProfile", err, "user_id", userID.String())
+		return nil, err
+	}
+	if user == nil {
+		logWarn("GetProfile", "user not found", "user_id", userID.String())
+		return nil, domainErrors.ErrUserNotFound
+	}
+
+	return user, nil
+}
+
 // formatErrors は複数のエラーをカンマ区切りの文字列に変換する
 func formatErrors(errs []error) string {
 	msgs := make([]string, len(errs))


### PR DESCRIPTION
## Summary
- UserUsecaseにGetProfileメソッドを追加
- 認証ユーザーのプロフィール情報を取得可能に
- 読み取り専用のためトランザクション不使用

## Test plan
- [x] 正常系_プロフィール取得成功（全フィールド検証）
- [x] 異常系_ユーザーが見つからない
- [x] 異常系_リポジトリエラー

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)