### PR TITLE
feat(handler): ユーザープロフィール取得エンドポイントを追加

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -73,6 +73,7 @@ require (
 	go.opentelemetry.io/otel v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.uber.org/mock v0.6.0 // indirect
 	golang.org/x/arch v0.8.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.49.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -185,6 +185,8 @@ go.opentelemetry.io/otel/sdk/metric v1.38.0 h1:aSH66iL0aZqo//xXzQLYozmWrXxyFkBJ6
 go.opentelemetry.io/otel/sdk/metric v1.38.0/go.mod h1:dg9PBnW9XdQ1Hd6ZnRz689CbtrUp0wMMs9iPcgT9EZA=
 go.opentelemetry.io/otel/trace v1.39.0 h1:2d2vfpEDmCJ5zVYz7ijaJdOF59xLomrvj7bjt6/qCJI=
 go.opentelemetry.io/otel/trace v1.39.0/go.mod h1:88w4/PnZSazkGzz/w84VHpQafiU4EtqqlVdxWy+rNOA=
+go.uber.org/mock v0.6.0 h1:hyF9dfmbgIX5EfOdasqLsWD6xqpNZlXblLB/Dbnwv3Y=
+go.uber.org/mock v0.6.0/go.mod h1:KiVJ4BqZJaMj4svdfmHM0AUx4NJYO8ZNpPnZn1Z+BBU=
 golang.org/x/arch v0.0.0-20210923205945-b76863e36670/go.mod h1:5om86z9Hs0C8fWVUuoMHwpExlXzs5Tkyp9hOrfG7pp8=
 golang.org/x/arch v0.8.0 h1:3wRIsP3pM4yUptoR96otTUOXI367OS0+c9eeRi9doIc=
 golang.org/x/arch v0.8.0/go.mod h1:FEVrYAQjsQXMVJ1nsMoVVXPZg6p2JE2mx8psSWTDQys=

--- a/backend/handler/user/dto/response.go
+++ b/backend/handler/user/dto/response.go
@@ -27,3 +27,27 @@ func NewUpdateProfileResponse(user *entity.User) UpdateProfileResponse {
 		ActivityLevel: user.ActivityLevel().String(),
 	}
 }
+
+// GetProfileResponse はプロフィール取得レスポンスDTO
+type GetProfileResponse struct {
+	Email         string  `json:"email" example:"user@example.com"`
+	Nickname      string  `json:"nickname" example:"John"`
+	Weight        float64 `json:"weight" example:"70.5"`
+	Height        float64 `json:"height" example:"175.0"`
+	BirthDate     string  `json:"birthDate" example:"1990-01-15"`
+	Gender        string  `json:"gender" example:"male"`
+	ActivityLevel string  `json:"activityLevel" example:"moderate"`
+}
+
+// NewGetProfileResponse はEntityからレスポンスDTOを生成する
+func NewGetProfileResponse(user *entity.User) GetProfileResponse {
+	return GetProfileResponse{
+		Email:         user.Email().String(),
+		Nickname:      user.Nickname().String(),
+		Weight:        user.Weight().Kg(),
+		Height:        user.Height().Cm(),
+		BirthDate:     user.BirthDate().Time().Format("2006-01-02"),
+		Gender:        user.Gender().String(),
+		ActivityLevel: user.ActivityLevel().String(),
+	}
+}

--- a/backend/handler/user/handler.go
+++ b/backend/handler/user/handler.go
@@ -62,6 +62,25 @@ func (h *UserHandler) Register(c *gin.Context) {
 	})
 }
 
+// GetProfile は認証ユーザーのプロフィールを取得する
+func (h *UserHandler) GetProfile(c *gin.Context) {
+	userIDStr, exists := c.Get("userID")
+	if !exists {
+		common.RespondError(c, http.StatusUnauthorized, common.CodeUnauthorized, "User not authenticated", nil)
+		return
+	}
+
+	userID := vo.ReconstructUserID(userIDStr.(string))
+
+	user, err := h.usecase.GetProfile(c.Request.Context(), userID)
+	if err != nil {
+		h.handleError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.NewGetProfileResponse(user))
+}
+
 // UpdateProfile は認証ユーザーのプロフィールを更新する
 func (h *UserHandler) UpdateProfile(c *gin.Context) {
 	userIDStr, exists := c.Get("userID")

--- a/backend/main.go
+++ b/backend/main.go
@@ -108,6 +108,7 @@ func main() {
 	authenticated := api.Group("")
 	authenticated.Use(middleware.AuthMiddleware(authUsecase))
 	{
+		authenticated.GET("/users/profile", userHandler.GetProfile)
 		authenticated.PATCH("/users/profile", userHandler.UpdateProfile)
 		authenticated.POST("/records", recordHandler.Create)
 		authenticated.GET("/records/today", recordHandler.GetToday)


### PR DESCRIPTION
## Summary
- GET /api/v1/users/profile エンドポイントを追加
- GetProfileResponse DTO（7フィールド: email, nickname, weight, height, birthDate, gender, activityLevel）
- userId, createdAt, updatedAt はレスポンスから除外

## Test plan
- [x] 正常系_プロフィール取得成功（全7フィールド検証 + 除外フィールド確認）
- [x] 異常系_認証なし
- [x] 異常系_ユーザーが見つからない
- [x] 異常系_DB取得失敗

Closes #203

Generated with [Claude Code](https://claude.com/claude-code)