### PR TITLE
feat(frontend): ユーザー編集フォームと設定ページを追加

### DIFF
--- a/backend/usecase/nutrition_test.go
+++ b/backend/usecase/nutrition_test.go
@@ -8,162 +8,48 @@ import (
 
 	"caltrack/domain/entity"
 	domainErrors "caltrack/domain/errors"
-	"caltrack/domain/repository"
 	"caltrack/domain/vo"
+	"caltrack/mock"
 	"caltrack/usecase"
 	"caltrack/usecase/service"
+
+	gomock "go.uber.org/mock/gomock"
 )
 
-// mockAdviceCacheRepository はAdviceCacheRepositoryのモック実装
-type mockAdviceCacheRepository struct {
-	save                 func(ctx context.Context, cache *entity.AdviceCache) error
-	findByUserIDAndDate  func(ctx context.Context, userID vo.UserID, date time.Time) (*entity.AdviceCache, error)
-	deleteByUserIDAndDate func(ctx context.Context, userID vo.UserID, date time.Time) error
-}
-
-func (m *mockAdviceCacheRepository) Save(ctx context.Context, cache *entity.AdviceCache) error {
-	if m.save != nil {
-		return m.save(ctx, cache)
-	}
-	return nil
-}
-
-func (m *mockAdviceCacheRepository) FindByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) (*entity.AdviceCache, error) {
-	if m.findByUserIDAndDate != nil {
-		return m.findByUserIDAndDate(ctx, userID, date)
-	}
-	return nil, nil
-}
-
-func (m *mockAdviceCacheRepository) DeleteByUserIDAndDate(ctx context.Context, userID vo.UserID, date time.Time) error {
-	if m.deleteByUserIDAndDate != nil {
-		return m.deleteByUserIDAndDate(ctx, userID, date)
-	}
-	return nil
-}
-
-// mockPfcAnalyzer はPfcAnalyzerのモック実装
-type mockPfcAnalyzer struct {
-	analyze func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error)
-}
-
-func (m *mockPfcAnalyzer) Analyze(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
-	if m.analyze != nil {
-		return m.analyze(ctx, config, input)
-	}
-	return &service.NutritionAdviceOutput{Advice: "テストアドバイス"}, nil
-}
-
-// mockNutritionUserRepository はUserRepositoryのモック実装（Nutrition用）
-type mockNutritionUserRepository struct {
-	findByID func(ctx context.Context, id vo.UserID) (*entity.User, error)
-}
-
-func (m *mockNutritionUserRepository) Save(ctx context.Context, user *entity.User) error {
-	return nil
-}
-
-func (m *mockNutritionUserRepository) FindByEmail(ctx context.Context, email vo.Email) (*entity.User, error) {
-	return nil, nil
-}
-
-func (m *mockNutritionUserRepository) ExistsByEmail(ctx context.Context, email vo.Email) (bool, error) {
-	return false, nil
-}
-
-func (m *mockNutritionUserRepository) FindByID(ctx context.Context, id vo.UserID) (*entity.User, error) {
-	if m.findByID != nil {
-		return m.findByID(ctx, id)
-	}
-	return nil, nil
-}
-
-func (m *mockNutritionUserRepository) Update(ctx context.Context, user *entity.User) error {
-	return nil
-}
-
-// mockNutritionRecordRepository はRecordRepositoryのモック実装（Nutrition用）
-type mockNutritionRecordRepository struct {
-	findByUserIDAndDateRange func(ctx context.Context, userID vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error)
-}
-
-func (m *mockNutritionRecordRepository) Save(ctx context.Context, record *entity.Record) error {
-	return nil
-}
-
-func (m *mockNutritionRecordRepository) FindByUserIDAndDateRange(ctx context.Context, userID vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-	if m.findByUserIDAndDateRange != nil {
-		return m.findByUserIDAndDateRange(ctx, userID, startTime, endTime)
-	}
-	return nil, nil
-}
-
-func (m *mockNutritionRecordRepository) GetDailyCalories(ctx context.Context, userID vo.UserID, period vo.StatisticsPeriod) ([]repository.DailyCalories, error) {
-	return nil, nil
-}
-
-// mockNutritionRecordPfcRepository はRecordPfcRepositoryのモック実装（Nutrition用）
-type mockNutritionRecordPfcRepository struct {
-	findByRecordIDs func(ctx context.Context, recordIDs []vo.RecordID) ([]*entity.RecordPfc, error)
-}
-
-func (m *mockNutritionRecordPfcRepository) Save(ctx context.Context, recordPfc *entity.RecordPfc) error {
-	return nil
-}
-
-func (m *mockNutritionRecordPfcRepository) FindByRecordID(ctx context.Context, recordID vo.RecordID) (*entity.RecordPfc, error) {
-	return nil, nil
-}
-
-func (m *mockNutritionRecordPfcRepository) FindByRecordIDs(ctx context.Context, recordIDs []vo.RecordID) ([]*entity.RecordPfc, error) {
-	if m.findByRecordIDs != nil {
-		return m.findByRecordIDs(ctx, recordIDs)
-	}
-	return nil, nil
-}
-
-// validUserForNutrition はNutrition用テストのための有効なUserを生成する
-func validUserForNutrition(t *testing.T, userID vo.UserID) *entity.User {
+// setupNutritionMocks はテスト用のモックを初期化する
+func setupNutritionMocks(t *testing.T) (
+	*mock.MockUserRepository,
+	*mock.MockRecordRepository,
+	*mock.MockRecordPfcRepository,
+	*mock.MockAdviceCacheRepository,
+	*mock.MockPfcAnalyzer,
+	*gomock.Controller,
+) {
 	t.Helper()
-	user, err := entity.ReconstructUser(
-		userID.String(),
-		"test@example.com",
-		"hashedpassword",
-		"testuser",
-		70.0,
-		175.0,
-		time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC),
-		"male",
-		"moderate",
-		time.Now(),
-		time.Now(),
-	)
-	if err != nil {
-		t.Fatalf("failed to create valid user: %v", err)
-	}
-	return user
+	ctrl := gomock.NewController(t)
+	return mock.NewMockUserRepository(ctrl),
+		mock.NewMockRecordRepository(ctrl),
+		mock.NewMockRecordPfcRepository(ctrl),
+		mock.NewMockAdviceCacheRepository(ctrl),
+		mock.NewMockPfcAnalyzer(ctrl),
+		ctrl
 }
 
 func TestNutritionUsecase_GetAdvice(t *testing.T) {
 	t.Run("正常系_今日の記録がない場合は固定文言が返される", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
-		user := validUserForNutrition(t, userID)
+		user := validUserForRecord(t, userID)
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return user, nil
-			},
-		}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
 
-		recordRepo := &mockNutritionRecordRepository{
-			findByUserIDAndDateRange: func(ctx context.Context, uid vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-				return []*entity.Record{}, nil
-			},
-		}
-
-		recordPfcRepo := &mockNutritionRecordPfcRepository{}
-		adviceCacheRepo := &mockAdviceCacheRepository{}
-		analyzer := &mockPfcAnalyzer{}
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return([]*entity.Record{}, nil)
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		output, err := uc.GetAdvice(context.Background(), userID)
@@ -178,8 +64,11 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 	})
 
 	t.Run("正常系_キャッシュがある場合はキャッシュが返される", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
-		user := validUserForNutrition(t, userID)
+		user := validUserForRecord(t, userID)
 
 		// 今日のRecordを作成
 		record1, _ := entity.NewRecord(userID, time.Now())
@@ -189,34 +78,19 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 		cachedAdvice := "キャッシュされたアドバイス"
 		cache := entity.NewAdviceCache(userID, time.Now(), cachedAdvice)
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return user, nil
-			},
-		}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
 
-		recordRepo := &mockNutritionRecordRepository{
-			findByUserIDAndDateRange: func(ctx context.Context, uid vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-				return records, nil
-			},
-		}
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return(records, nil)
 
-		recordPfcRepo := &mockNutritionRecordPfcRepository{}
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(cache, nil)
 
-		adviceCacheRepo := &mockAdviceCacheRepository{
-			findByUserIDAndDate: func(ctx context.Context, uid vo.UserID, date time.Time) (*entity.AdviceCache, error) {
-				return cache, nil
-			},
-		}
-
-		// AI呼び出しは行われないはず
-		analyzerCalled := false
-		analyzer := &mockPfcAnalyzer{
-			analyze: func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
-				analyzerCalled = true
-				return &service.NutritionAdviceOutput{Advice: "新しいアドバイス"}, nil
-			},
-		}
+		// analyzer.Analyzeは呼ばれないこと（EXPECTを設定しないことで検証）
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		output, err := uc.GetAdvice(context.Background(), userID)
@@ -228,15 +102,14 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 		if output.Advice != cachedAdvice {
 			t.Errorf("Advice = %s, want %s", output.Advice, cachedAdvice)
 		}
-
-		if analyzerCalled {
-			t.Error("Analyzer should not be called when cache exists")
-		}
 	})
 
 	t.Run("正常系_キャッシュがない場合はAI呼び出し後にキャッシュ保存される", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
-		user := validUserForNutrition(t, userID)
+		user := validUserForRecord(t, userID)
 
 		// 今日のRecordを作成
 		record1, _ := entity.NewRecord(userID, time.Now())
@@ -251,46 +124,40 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 		recordPfc1 := entity.NewRecordPfc(record1.ID(), 15.0, 10.0, 40.0)
 		recordPfc2 := entity.NewRecordPfc(record2.ID(), 20.0, 15.0, 60.0)
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return user, nil
-			},
-		}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
 
-		recordRepo := &mockNutritionRecordRepository{
-			findByUserIDAndDateRange: func(ctx context.Context, uid vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-				return records, nil
-			},
-		}
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return(records, nil)
 
-		recordPfcRepo := &mockNutritionRecordPfcRepository{
-			findByRecordIDs: func(ctx context.Context, recordIDs []vo.RecordID) ([]*entity.RecordPfc, error) {
-				return []*entity.RecordPfc{recordPfc1, recordPfc2}, nil
-			},
-		}
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(nil, nil) // キャッシュなし
 
-		var savedCache *entity.AdviceCache
-		adviceCacheRepo := &mockAdviceCacheRepository{
-			findByUserIDAndDate: func(ctx context.Context, uid vo.UserID, date time.Time) (*entity.AdviceCache, error) {
-				return nil, nil // キャッシュなし
-			},
-			save: func(ctx context.Context, cache *entity.AdviceCache) error {
-				savedCache = cache
-				return nil
-			},
-		}
+		recordPfcRepo.EXPECT().
+			FindByRecordIDs(gomock.Any(), gomock.Any()).
+			Return([]*entity.RecordPfc{recordPfc1, recordPfc2}, nil)
 
-		analyzerCalled := false
-		analyzer := &mockPfcAnalyzer{
-			analyze: func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
-				analyzerCalled = true
+		analyzer.EXPECT().
+			Analyze(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
 				// プロンプトが構築されていることを確認
 				if config.Prompt == "" {
 					t.Error("Prompt should not be empty")
 				}
 				return &service.NutritionAdviceOutput{Advice: "バランスの良い食事ができています"}, nil
-			},
-		}
+			})
+
+		adviceCacheRepo.EXPECT().
+			Save(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, cache *entity.AdviceCache) error {
+				if cache.Advice() != "バランスの良い食事ができています" {
+					t.Errorf("Saved cache advice = %s, want %s", cache.Advice(), "バランスの良い食事ができています")
+				}
+				return nil
+			})
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		output, err := uc.GetAdvice(context.Background(), userID)
@@ -306,34 +173,17 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 		if output.Advice != "バランスの良い食事ができています" {
 			t.Errorf("Advice = %s, want %s", output.Advice, "バランスの良い食事ができています")
 		}
-
-		if !analyzerCalled {
-			t.Error("Analyzer should be called when cache does not exist")
-		}
-
-		if savedCache == nil {
-			t.Error("Cache should be saved")
-		}
-
-		if savedCache != nil && savedCache.Advice() != "バランスの良い食事ができています" {
-			t.Errorf("Saved cache advice = %s, want %s", savedCache.Advice(), "バランスの良い食事ができています")
-		}
 	})
 
-
 	t.Run("異常系_ユーザーが存在しない", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return nil, nil
-			},
-		}
-
-		recordRepo := &mockNutritionRecordRepository{}
-		recordPfcRepo := &mockNutritionRecordPfcRepository{}
-		adviceCacheRepo := &mockAdviceCacheRepository{}
-		analyzer := &mockPfcAnalyzer{}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(nil, nil)
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		_, err := uc.GetAdvice(context.Background(), userID)
@@ -344,19 +194,15 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 	})
 
 	t.Run("異常系_ユーザー取得時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
 		repoErr := errors.New("db error")
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return nil, repoErr
-			},
-		}
-
-		recordRepo := &mockNutritionRecordRepository{}
-		recordPfcRepo := &mockNutritionRecordPfcRepository{}
-		adviceCacheRepo := &mockAdviceCacheRepository{}
-		analyzer := &mockPfcAnalyzer{}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(nil, repoErr)
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		_, err := uc.GetAdvice(context.Background(), userID)
@@ -367,25 +213,20 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 	})
 
 	t.Run("異常系_Record取得時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
-		user := validUserForNutrition(t, userID)
+		user := validUserForRecord(t, userID)
 		repoErr := errors.New("db error")
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return user, nil
-			},
-		}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
 
-		recordRepo := &mockNutritionRecordRepository{
-			findByUserIDAndDateRange: func(ctx context.Context, uid vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-				return nil, repoErr
-			},
-		}
-
-		recordPfcRepo := &mockNutritionRecordPfcRepository{}
-		adviceCacheRepo := &mockAdviceCacheRepository{}
-		analyzer := &mockPfcAnalyzer{}
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return(nil, repoErr)
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		_, err := uc.GetAdvice(context.Background(), userID)
@@ -396,38 +237,31 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 	})
 
 	t.Run("異常系_RecordPfc取得時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
-		user := validUserForNutrition(t, userID)
+		user := validUserForRecord(t, userID)
 		repoErr := errors.New("db error")
 
 		record1, _ := entity.NewRecord(userID, time.Now())
 		_ = record1.AddItem("朝食", 300)
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return user, nil
-			},
-		}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
 
-		recordRepo := &mockNutritionRecordRepository{
-			findByUserIDAndDateRange: func(ctx context.Context, uid vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-				return []*entity.Record{record1}, nil
-			},
-		}
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return([]*entity.Record{record1}, nil)
 
-		recordPfcRepo := &mockNutritionRecordPfcRepository{
-			findByRecordIDs: func(ctx context.Context, recordIDs []vo.RecordID) ([]*entity.RecordPfc, error) {
-				return nil, repoErr
-			},
-		}
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(nil, nil)
 
-		adviceCacheRepo := &mockAdviceCacheRepository{
-			findByUserIDAndDate: func(ctx context.Context, uid vo.UserID, date time.Time) (*entity.AdviceCache, error) {
-				return nil, nil
-			},
-		}
-
-		analyzer := &mockPfcAnalyzer{}
+		recordPfcRepo.EXPECT().
+			FindByRecordIDs(gomock.Any(), gomock.Any()).
+			Return(nil, repoErr)
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		_, err := uc.GetAdvice(context.Background(), userID)
@@ -438,42 +272,35 @@ func TestNutritionUsecase_GetAdvice(t *testing.T) {
 	})
 
 	t.Run("異常系_PfcAnalyzer実行時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
 		userID := vo.NewUserID()
-		user := validUserForNutrition(t, userID)
+		user := validUserForRecord(t, userID)
 		analyzeErr := errors.New("analyzer error")
 
 		record1, _ := entity.NewRecord(userID, time.Now())
 		_ = record1.AddItem("朝食", 300)
 
-		userRepo := &mockNutritionUserRepository{
-			findByID: func(ctx context.Context, id vo.UserID) (*entity.User, error) {
-				return user, nil
-			},
-		}
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
 
-		recordRepo := &mockNutritionRecordRepository{
-			findByUserIDAndDateRange: func(ctx context.Context, uid vo.UserID, startTime, endTime time.Time) ([]*entity.Record, error) {
-				return []*entity.Record{record1}, nil
-			},
-		}
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return([]*entity.Record{record1}, nil)
 
-		recordPfcRepo := &mockNutritionRecordPfcRepository{
-			findByRecordIDs: func(ctx context.Context, recordIDs []vo.RecordID) ([]*entity.RecordPfc, error) {
-				return []*entity.RecordPfc{}, nil
-			},
-		}
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(nil, nil)
 
-		adviceCacheRepo := &mockAdviceCacheRepository{
-			findByUserIDAndDate: func(ctx context.Context, uid vo.UserID, date time.Time) (*entity.AdviceCache, error) {
-				return nil, nil
-			},
-		}
+		recordPfcRepo.EXPECT().
+			FindByRecordIDs(gomock.Any(), gomock.Any()).
+			Return([]*entity.RecordPfc{}, nil)
 
-		analyzer := &mockPfcAnalyzer{
-			analyze: func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
-				return nil, analyzeErr
-			},
-		}
+		analyzer.EXPECT().
+			Analyze(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, analyzeErr)
 
 		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
 		_, err := uc.GetAdvice(context.Background(), userID)

--- a/frontend/src/features/common/hooks/useForm.ts
+++ b/frontend/src/features/common/hooks/useForm.ts
@@ -30,7 +30,6 @@ export type UseFormReturn<F extends string> = {
   reset: () => void;
   isValid: boolean;
   isPending: boolean;
-  setFormState: React.Dispatch<React.SetStateAction<Record<F, string>>>;
 };
 
 /**
@@ -72,6 +71,14 @@ export function useForm<F extends string, T, D = unknown>(
 
   const [formState, setFormState] = useState(initialFormState);
   const [errors, setErrors] = useState(initialErrors);
+
+  // React公式推奨: レンダー中にprops変更を検知してstateを同期
+  const [prevInitialFormState, setPrevInitialFormState] = useState(initialFormState);
+  if (initialFormState !== prevInitialFormState) {
+    setPrevInitialFormState(initialFormState);
+    setFormState(initialFormState);
+    setErrors(initialErrors);
+  }
 
   // SWRベースのmutationフック
   const { trigger, isMutating, error: apiError, reset: resetMutation } = useRequestMutation<T, D>(
@@ -138,6 +145,5 @@ export function useForm<F extends string, T, D = unknown>(
     reset,
     isValid,
     isPending: isMutating,
-    setFormState,
   };
 }

--- a/frontend/src/features/user/api/index.ts
+++ b/frontend/src/features/user/api/index.ts
@@ -1,0 +1,33 @@
+/**
+ * User API 型定義
+ * ユーザープロフィールの取得・更新に関するAPI型
+ */
+import type { ActivityLevelValue } from "@/domain/valueObjects";
+
+/** プロフィール更新リクエスト */
+export type UpdateProfileRequest = {
+  nickname: string;
+  height: number;
+  weight: number;
+  activityLevel: string;
+};
+
+/** プロフィール更新レスポンス */
+export type UpdateProfileResponse = {
+  userId: string;
+  nickname: string;
+  height: number;
+  weight: number;
+  activityLevel: string;
+};
+
+/** 現在のユーザー情報レスポンス */
+export type CurrentUserResponse = {
+  email: string;
+  nickname: string;
+  weight: number;
+  height: number;
+  birthDate: string;
+  gender: string;
+  activityLevel: ActivityLevelValue;
+};

--- a/frontend/src/features/user/components/ProfileEditForm.stories.tsx
+++ b/frontend/src/features/user/components/ProfileEditForm.stories.tsx
@@ -1,0 +1,102 @@
+/**
+ * ProfileEditForm - Storybookストーリー
+ * プロフィール編集フォームの各状態の表示確認
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { SWRConfig } from "swr";
+import { ProfileEditForm } from "./ProfileEditForm";
+import type { CurrentUserResponse } from "../api";
+
+const meta: Meta<typeof ProfileEditForm> = {
+  title: "Features/User/ProfileEditForm",
+  component: ProfileEditForm,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[480px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ProfileEditForm>;
+
+/** モックユーザーデータ */
+const mockUser: CurrentUserResponse = {
+  email: "test@example.com",
+  nickname: "テストユーザー",
+  weight: 70,
+  height: 175,
+  birthDate: "1990-01-01",
+  gender: "male",
+  activityLevel: "moderate",
+};
+
+/** デフォルト表示（ユーザーデータ読み込み完了後） */
+export const Default: Story = {
+  decorators: [
+    (Story) => (
+      <SWRConfig
+        value={{
+          dedupingInterval: 0,
+          provider: () => new Map(),
+          fetcher: async () => mockUser,
+        }}
+      >
+        <Story />
+      </SWRConfig>
+    ),
+  ],
+  args: {
+    onSuccess: (response) => {
+      console.log("更新成功:", response);
+      alert("プロフィールを更新しました！");
+    },
+  },
+};
+
+/** Loading状態（データ読み込み中） */
+export const Loading: Story = {
+  decorators: [
+    (Story) => (
+      <SWRConfig
+        value={{
+          dedupingInterval: 0,
+          provider: () => new Map(),
+          fetcher: async () => {
+            // 永遠に解決しないPromiseでローディング状態を再現
+            return new Promise(() => {});
+          },
+        }}
+      >
+        <Story />
+      </SWRConfig>
+    ),
+  ],
+  args: {},
+};
+
+/** FetchError状態（データ取得エラー） */
+export const FetchError: Story = {
+  decorators: [
+    (Story) => (
+      <SWRConfig
+        value={{
+          dedupingInterval: 0,
+          provider: () => new Map(),
+          fetcher: async () => {
+            throw { code: "INTERNAL_ERROR", message: "サーバーエラーが発生しました" };
+          },
+        }}
+      >
+        <Story />
+      </SWRConfig>
+    ),
+  ],
+  args: {},
+};

--- a/frontend/src/features/user/components/ProfileEditForm.tsx
+++ b/frontend/src/features/user/components/ProfileEditForm.tsx
@@ -1,0 +1,306 @@
+/**
+ * ProfileEditForm - プロフィール編集フォームコンポーネント
+ * ユーザー情報（ニックネーム、体重、身長、活動レベル）の編集UI
+ * Warm & Organicトーンのデザイン
+ */
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectOption } from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { getApiErrorMessage } from "@/features/common";
+import { ACTIVITY_LEVEL_OPTIONS } from "@/domain/valueObjects";
+import { useCurrentUser } from "../hooks/useCurrentUser";
+import { useUpdateProfile } from "../hooks/useUpdateProfile";
+import type { UpdateProfileResponse } from "../api";
+
+/**
+ * AlertCircleアイコン - エラー表示用
+ * SVGインラインアイコン
+ */
+function AlertCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  );
+}
+
+/**
+ * フィールドエラー表示コンポーネント
+ * アイコン付きのエラーメッセージを表示
+ */
+function FieldError({ id, message }: { id: string; message: string }) {
+  return (
+    <p id={id} className="flex items-center gap-1.5 text-sm text-destructive">
+      <AlertCircleIcon className="w-4 h-4 flex-shrink-0" />
+      <span>{message}</span>
+    </p>
+  );
+}
+
+/**
+ * ローディングスケルトン - データ読み込み中の表示
+ */
+function LoadingSkeleton() {
+  return (
+    <Card className="w-full shadow-warm-lg border-0">
+      <CardHeader className="space-y-1 pb-6">
+        <Skeleton className="h-8 w-48 mx-auto" />
+        <Skeleton className="h-4 w-64 mx-auto" />
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-11 w-full" />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-11 w-full" />
+            </div>
+            <div className="space-y-2">
+              <Skeleton className="h-5 w-24" />
+              <Skeleton className="h-11 w-full" />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Skeleton className="h-5 w-32" />
+            <Skeleton className="h-11 w-full" />
+          </div>
+          <div className="!mt-10">
+            <Skeleton className="h-12 w-full" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/** ProfileEditFormコンポーネントのProps */
+export type ProfileEditFormProps = {
+  /** 更新成功時のコールバック */
+  onSuccess?: (response: UpdateProfileResponse) => void;
+};
+
+/**
+ * ProfileEditForm - プロフィール編集フォーム
+ */
+export function ProfileEditForm({ onSuccess }: ProfileEditFormProps) {
+  const { data: currentUser, error: fetchError, isLoading } = useCurrentUser();
+  const {
+    formState,
+    errors,
+    apiError,
+    handleChange,
+    handleSubmit,
+    isValid,
+    isPending,
+  } = useUpdateProfile(currentUser, onSuccess);
+
+  // ローディング中
+  if (isLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  // 取得エラー
+  if (fetchError) {
+    return (
+      <Card className="w-full shadow-warm-lg border-0">
+        <CardContent className="pt-6">
+          <div
+            className="flex items-start gap-3 p-4 text-sm rounded-lg bg-destructive/10 border border-destructive/20"
+            role="alert"
+          >
+            <AlertCircleIcon className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="font-medium text-destructive">
+                プロフィールの読み込みに失敗しました
+              </p>
+              <p className="mt-1 text-destructive/80">
+                {getApiErrorMessage(fetchError.code)}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="w-full shadow-warm-lg border-0">
+      <CardHeader className="space-y-1 pb-6">
+        <CardTitle className="text-2xl font-semibold text-center">
+          プロフィール編集
+        </CardTitle>
+        <CardDescription className="text-center text-muted-foreground">
+          ユーザー情報を更新できます
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-5">
+          {/* APIエラー表示 */}
+          {apiError && (
+            <div
+              className="flex items-start gap-3 p-4 text-sm rounded-lg bg-destructive/10 border border-destructive/20"
+              role="alert"
+            >
+              <AlertCircleIcon className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
+              <div className="flex-1">
+                <p className="font-medium text-destructive">
+                  {getApiErrorMessage(apiError.code)}
+                </p>
+                {apiError.details && apiError.details.length > 0 && (
+                  <ul className="mt-1.5 list-disc list-inside text-destructive/80">
+                    {apiError.details.map((detail, index) => (
+                      <li key={index}>{detail}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* ニックネーム */}
+          <div className="space-y-2">
+            <Label htmlFor="nickname" className="text-foreground font-medium">
+              ニックネーム
+            </Label>
+            <Input
+              id="nickname"
+              name="nickname"
+              type="text"
+              value={formState.nickname}
+              onChange={(e) => handleChange("nickname")(e.target.value)}
+              placeholder="ニックネームを入力"
+              disabled={isPending}
+              aria-invalid={!!errors.nickname}
+              aria-describedby={errors.nickname ? "nickname-error" : undefined}
+              className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
+            />
+            {errors.nickname && (
+              <FieldError id="nickname-error" message={errors.nickname} />
+            )}
+          </div>
+
+          {/* 体重・身長（2カラム） */}
+          <div className="grid grid-cols-2 gap-4">
+            {/* 体重 */}
+            <div className="space-y-2">
+              <Label htmlFor="weight" className="text-foreground font-medium">
+                体重 (kg)
+              </Label>
+              <Input
+                id="weight"
+                name="weight"
+                type="number"
+                step="0.1"
+                min="0"
+                value={formState.weight}
+                onChange={(e) => handleChange("weight")(e.target.value)}
+                placeholder="60"
+                disabled={isPending}
+                aria-invalid={!!errors.weight}
+                aria-describedby={errors.weight ? "weight-error" : undefined}
+                className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
+              />
+              {errors.weight && (
+                <FieldError id="weight-error" message={errors.weight} />
+              )}
+            </div>
+
+            {/* 身長 */}
+            <div className="space-y-2">
+              <Label htmlFor="height" className="text-foreground font-medium">
+                身長 (cm)
+              </Label>
+              <Input
+                id="height"
+                name="height"
+                type="number"
+                step="0.1"
+                min="0"
+                value={formState.height}
+                onChange={(e) => handleChange("height")(e.target.value)}
+                placeholder="170"
+                disabled={isPending}
+                aria-invalid={!!errors.height}
+                aria-describedby={errors.height ? "height-error" : undefined}
+                className="h-11 bg-background border-input focus:border-primary focus:ring-primary/20"
+              />
+              {errors.height && (
+                <FieldError id="height-error" message={errors.height} />
+              )}
+            </div>
+          </div>
+
+          {/* 活動レベル */}
+          <div className="space-y-2">
+            <Label
+              htmlFor="activityLevel"
+              className="text-foreground font-medium"
+            >
+              活動レベル
+            </Label>
+            <Select
+              id="activityLevel"
+              name="activityLevel"
+              value={formState.activityLevel}
+              onChange={(e) => handleChange("activityLevel")(e.target.value)}
+              disabled={isPending}
+              aria-invalid={!!errors.activityLevel}
+              aria-describedby={
+                errors.activityLevel ? "activityLevel-error" : undefined
+              }
+              className="h-11"
+            >
+              <SelectOption value="">選択してください</SelectOption>
+              {ACTIVITY_LEVEL_OPTIONS.map((option) => (
+                <SelectOption key={option.value} value={option.value}>
+                  {option.label}
+                </SelectOption>
+              ))}
+            </Select>
+            {errors.activityLevel && (
+              <FieldError
+                id="activityLevel-error"
+                message={errors.activityLevel}
+              />
+            )}
+          </div>
+
+          {/* 送信ボタン */}
+          <div className="!mt-10">
+            <Button
+              type="submit"
+              className="w-full h-12 text-base font-medium bg-primary hover:bg-primary/90 transition-colors"
+              disabled={!isValid || isPending}
+            >
+              {isPending ? "更新中..." : "更新する"}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/user/components/index.ts
+++ b/frontend/src/features/user/components/index.ts
@@ -1,0 +1,6 @@
+/**
+ * User Components
+ * ユーザー関連コンポーネントのエクスポート
+ */
+export { ProfileEditForm } from "./ProfileEditForm";
+export type { ProfileEditFormProps } from "./ProfileEditForm";

--- a/frontend/src/features/user/hooks/index.ts
+++ b/frontend/src/features/user/hooks/index.ts
@@ -1,0 +1,6 @@
+/**
+ * User Hooks
+ * ユーザー関連フックのエクスポート
+ */
+export { useCurrentUser } from "./useCurrentUser";
+export { useUpdateProfile } from "./useUpdateProfile";

--- a/frontend/src/features/user/hooks/useCurrentUser.ts
+++ b/frontend/src/features/user/hooks/useCurrentUser.ts
@@ -1,0 +1,22 @@
+/**
+ * useCurrentUser - プロフィール取得フック
+ * 現在のユーザー情報を取得する
+ */
+import { useRequestGet } from "@/features/common/hooks";
+import type { CurrentUserResponse } from "../api";
+
+/**
+ * useCurrentUser - プロフィール取得
+ */
+export function useCurrentUser() {
+  const { data, error, isLoading, mutate } = useRequestGet<CurrentUserResponse>(
+    "/api/v1/users/profile"
+  );
+
+  return {
+    data,
+    error,
+    isLoading,
+    refetch: mutate,
+  };
+}

--- a/frontend/src/features/user/hooks/useUpdateProfile.test.ts
+++ b/frontend/src/features/user/hooks/useUpdateProfile.test.ts
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useUpdateProfile } from "./useUpdateProfile";
+import type { CurrentUserResponse, UpdateProfileResponse } from "../api";
+
+// SWR mutationをモック
+const mockTrigger = vi.fn();
+const mockReset = vi.fn();
+const mockError = undefined;
+
+vi.mock("@/features/common/hooks/useRequest", () => ({
+  useRequestMutation: () => ({
+    trigger: mockTrigger,
+    isMutating: false,
+    error: mockError,
+    data: undefined,
+    reset: mockReset,
+  }),
+}));
+
+// VOファクトリをモック
+vi.mock("@/domain/valueObjects", async () => {
+  const actual = await vi.importActual("@/domain/valueObjects");
+  return actual;
+});
+
+describe("useUpdateProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("初期化", () => {
+    it("currentUserがundefinedの場合は空フォームで初期化される", () => {
+      const { result } = renderHook(() => useUpdateProfile(undefined));
+
+      expect(result.current.formState).toEqual({
+        nickname: "",
+        height: "",
+        weight: "",
+        activityLevel: "",
+      });
+      expect(result.current.errors).toEqual({
+        nickname: null,
+        height: null,
+        weight: null,
+        activityLevel: null,
+      });
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it("currentUserがある場合はユーザー情報で初期化される", () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const { result } = renderHook(() => useUpdateProfile(mockUser));
+
+      expect(result.current.formState).toEqual({
+        nickname: "テストユーザー",
+        height: "175",
+        weight: "70",
+        activityLevel: "moderate",
+      });
+    });
+  });
+
+  describe("currentUser変更時の同期", () => {
+    it("currentUserがundefinedからデータに変化したらフォーム状態が同期される", () => {
+      const { result, rerender } = renderHook(
+        ({ user }: { user: CurrentUserResponse | undefined }) => useUpdateProfile(user),
+        { initialProps: { user: undefined as CurrentUserResponse | undefined } }
+      );
+
+      // 初期状態は空
+      expect(result.current.formState.nickname).toBe("");
+
+      // ユーザーデータを設定
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "新ユーザー",
+        weight: 60,
+        height: 160,
+        birthDate: "1995-05-15",
+        gender: "female",
+        activityLevel: "light",
+      };
+
+      rerender({ user: mockUser });
+
+      // フォーム状態が同期される
+      expect(result.current.formState).toEqual({
+        nickname: "新ユーザー",
+        height: "160",
+        weight: "60",
+        activityLevel: "light",
+      });
+    });
+
+    it("別のユーザーに変化したらフォーム状態が同期される", () => {
+      const user1: CurrentUserResponse = {
+        email: "user1@example.com",
+        nickname: "ユーザー1",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const { result, rerender } = renderHook(
+        ({ user }: { user: CurrentUserResponse | undefined }) => useUpdateProfile(user),
+        { initialProps: { user: user1 as CurrentUserResponse | undefined } }
+      );
+
+      expect(result.current.formState.nickname).toBe("ユーザー1");
+
+      // 別ユーザーに変更
+      const user2: CurrentUserResponse = {
+        email: "user2@example.com",
+        nickname: "ユーザー2",
+        weight: 65,
+        height: 170,
+        birthDate: "1992-03-20",
+        gender: "female",
+        activityLevel: "veryActive",
+      };
+
+      rerender({ user: user2 });
+
+      // フォーム状態が更新される
+      expect(result.current.formState).toEqual({
+        nickname: "ユーザー2",
+        height: "170",
+        weight: "65",
+        activityLevel: "veryActive",
+      });
+    });
+
+    it("同じ参照で再レンダーしても編集内容が維持される", () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const { result, rerender } = renderHook(
+        ({ user }: { user: CurrentUserResponse | undefined }) => useUpdateProfile(user),
+        { initialProps: { user: mockUser as CurrentUserResponse | undefined } }
+      );
+
+      // ユーザーが編集
+      act(() => {
+        result.current.handleChange("nickname")("編集後");
+      });
+
+      expect(result.current.formState.nickname).toBe("編集後");
+
+      // 同じ参照で再レンダー
+      rerender({ user: mockUser });
+
+      // 編集内容が維持される
+      expect(result.current.formState.nickname).toBe("編集後");
+    });
+  });
+
+  describe("バリデーション", () => {
+    it("currentUserのデータが有効な場合isValid=trueになる", () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const { result } = renderHook(() => useUpdateProfile(mockUser));
+
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it("フィールド変更時にバリデーションが実行される", () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const { result } = renderHook(() => useUpdateProfile(mockUser));
+
+      // 無効な体重を入力
+      act(() => {
+        result.current.handleChange("weight")("999");
+      });
+
+      // エラーが設定される
+      expect(result.current.errors.weight).not.toBeNull();
+      expect(result.current.isValid).toBe(false);
+    });
+  });
+
+  describe("送信", () => {
+    it("handleSubmitでAPIリクエストが送信される", async () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const mockResponse: UpdateProfileResponse = {
+        userId: "user-123",
+        nickname: "更新後",
+        weight: 75,
+        height: 175,
+        activityLevel: "moderate",
+      };
+
+      mockTrigger.mockResolvedValue(mockResponse);
+
+      const { result } = renderHook(() => useUpdateProfile(mockUser));
+
+      // ニックネームを変更
+      act(() => {
+        result.current.handleChange("nickname")("更新後");
+        result.current.handleChange("weight")("75");
+      });
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent;
+
+      await act(async () => {
+        await result.current.handleSubmit(mockEvent);
+      });
+
+      expect(mockEvent.preventDefault).toHaveBeenCalled();
+      expect(mockTrigger).toHaveBeenCalledWith({
+        nickname: "更新後",
+        height: 175,
+        weight: 75,
+        activityLevel: "moderate",
+      });
+    });
+
+    it("成功時にonSuccessが呼び出される", async () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const mockResponse: UpdateProfileResponse = {
+        userId: "user-123",
+        nickname: "更新後",
+        weight: 70,
+        height: 175,
+        activityLevel: "moderate",
+      };
+
+      mockTrigger.mockResolvedValue(mockResponse);
+
+      const onSuccess = vi.fn();
+      const { result } = renderHook(() => useUpdateProfile(mockUser, onSuccess));
+
+      const mockEvent = {
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent;
+
+      await act(async () => {
+        await result.current.handleSubmit(mockEvent);
+      });
+
+      expect(onSuccess).toHaveBeenCalledWith(mockResponse);
+    });
+  });
+
+  describe("リセット", () => {
+    it("resetでcurrentUserの値に戻る", () => {
+      const mockUser: CurrentUserResponse = {
+        email: "test@example.com",
+        nickname: "テストユーザー",
+        weight: 70,
+        height: 175,
+        birthDate: "1990-01-01",
+        gender: "male",
+        activityLevel: "moderate",
+      };
+
+      const { result } = renderHook(() => useUpdateProfile(mockUser));
+
+      // フィールドを変更
+      act(() => {
+        result.current.handleChange("nickname")("変更後");
+        result.current.handleChange("weight")("80");
+      });
+
+      expect(result.current.formState.nickname).toBe("変更後");
+      expect(result.current.formState.weight).toBe("80");
+
+      // リセット
+      act(() => {
+        result.current.reset();
+      });
+
+      // 元の値に戻る
+      expect(result.current.formState).toEqual({
+        nickname: "テストユーザー",
+        height: "175",
+        weight: "70",
+        activityLevel: "moderate",
+      });
+      expect(mockReset).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/features/user/hooks/useUpdateProfile.ts
+++ b/frontend/src/features/user/hooks/useUpdateProfile.ts
@@ -1,0 +1,83 @@
+/**
+ * useUpdateProfile - プロフィール更新フック
+ * プロフィールの更新処理を行う
+ */
+import { useMemo } from "react";
+import { useForm } from "@/features/common/hooks";
+import {
+  newNickname,
+  newHeight,
+  newWeight,
+  newActivityLevel,
+} from "@/domain/valueObjects";
+import type { UpdateProfileResponse, CurrentUserResponse, UpdateProfileRequest } from "../api";
+
+/** フォームフィールド型 */
+type ProfileField = "nickname" | "height" | "weight" | "activityLevel";
+
+/** VOファクトリ設定 */
+const formConfig = {
+  nickname: newNickname,
+  height: newHeight,
+  weight: newWeight,
+  activityLevel: newActivityLevel,
+};
+
+/** 空のフォーム状態 */
+const emptyFormState: Record<ProfileField, string> = {
+  nickname: "",
+  height: "",
+  weight: "",
+  activityLevel: "",
+};
+
+/** エラーの初期状態 */
+const initialErrors: Record<ProfileField, string | null> = {
+  nickname: null,
+  height: null,
+  weight: null,
+  activityLevel: null,
+};
+
+/**
+ * currentUserから初期フォーム状態を構築
+ */
+function buildFormState(user: CurrentUserResponse | undefined): Record<ProfileField, string> {
+  if (!user) return emptyFormState;
+  return {
+    nickname: user.nickname,
+    height: String(user.height),
+    weight: String(user.weight),
+    activityLevel: user.activityLevel,
+  };
+}
+
+/**
+ * useUpdateProfile - プロフィール更新フォーム
+ * @param currentUser - 現在のユーザー情報
+ * @param onSuccess - 成功時のコールバック
+ */
+export function useUpdateProfile(
+  currentUser: CurrentUserResponse | undefined,
+  onSuccess?: (result: UpdateProfileResponse) => void
+) {
+  const initialFormState = useMemo(
+    () => buildFormState(currentUser),
+    [currentUser],
+  );
+
+  return useForm<ProfileField, UpdateProfileResponse, UpdateProfileRequest>({
+    config: formConfig,
+    initialFormState,
+    initialErrors,
+    url: "/api/v1/users/profile",
+    method: "PATCH",
+    transformData: (data) => ({
+      nickname: data.nickname,
+      height: parseFloat(data.height),
+      weight: parseFloat(data.weight),
+      activityLevel: data.activityLevel,
+    }),
+    onSuccess,
+  });
+}

--- a/frontend/src/features/user/index.ts
+++ b/frontend/src/features/user/index.ts
@@ -1,0 +1,12 @@
+/**
+ * User Feature
+ * ユーザー管理機能のエクスポート
+ */
+export { ProfileEditForm } from "./components";
+export type { ProfileEditFormProps } from "./components";
+export { useCurrentUser, useUpdateProfile } from "./hooks";
+export type {
+  UpdateProfileRequest,
+  UpdateProfileResponse,
+  CurrentUserResponse,
+} from "./api";

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,87 @@
+/**
+ * SettingsPage - 設定ページ
+ * ユーザープロフィールの編集が可能
+ */
+import { useState, useEffect } from "react";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+import { ProfileEditForm } from "@/features/user";
+import type { UpdateProfileResponse } from "@/features/user";
+
+/**
+ * CheckCircleアイコン - 成功表示用
+ * SVGインラインアイコン
+ */
+function CheckCircleIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+      <polyline points="22 4 12 14.01 9 11.01" />
+    </svg>
+  );
+}
+
+/**
+ * SettingsPage - 設定ページコンポーネント
+ */
+export function SettingsPage() {
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  /**
+   * プロフィール更新成功時のコールバック
+   * 成功メッセージを3秒間表示
+   */
+  const handleUpdateSuccess = (_result: UpdateProfileResponse) => {
+    setSuccessMessage("プロフィールを更新しました");
+    setTimeout(() => {
+      setSuccessMessage(null);
+    }, 3000);
+  };
+
+  // 成功メッセージが変化したら、3秒後に消す
+  useEffect(() => {
+    if (successMessage) {
+      const timer = setTimeout(() => {
+        setSuccessMessage(null);
+      }, 3000);
+      return () => clearTimeout(timer);
+    }
+  }, [successMessage]);
+
+  return (
+    <div className="min-h-screen flex flex-col bg-background">
+      <Header />
+      <main className="flex-1 container px-4 py-8 mx-auto max-w-3xl">
+        <div className="space-y-6">
+          {/* ページタイトル */}
+          <h1 className="text-2xl font-bold">設定</h1>
+
+          {/* 成功メッセージ */}
+          {successMessage && (
+            <div
+              className="flex items-start gap-3 p-4 text-sm rounded-lg bg-green-50 border border-green-200"
+              role="alert"
+            >
+              <CheckCircleIcon className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
+              <p className="font-medium text-green-800">{successMessage}</p>
+            </div>
+          )}
+
+          {/* プロフィール編集フォーム */}
+          <ProfileEditForm onSuccess={handleUpdateSuccess} />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -10,6 +10,7 @@ import { HomePage } from "../pages/HomePage";
 import { DashboardPage } from "../pages/DashboardPage";
 import { RegisterPage } from "../pages/RegisterPage";
 import { LoginPage } from "../pages/LoginPage";
+import { SettingsPage } from "../pages/SettingsPage";
 
 /**
  * 認証関連のルート定義
@@ -38,6 +39,10 @@ const mainRoutes: RouteObject[] = [
   {
     path: "/dashboard",
     element: <DashboardPage />,
+  },
+  {
+    path: "/settings",
+    element: <SettingsPage />,
   },
   // 将来追加予定:
   // { path: "/meals", element: <MealsPage /> },


### PR DESCRIPTION
## Summary
- features/user/ にAPI型定義・hooks・componentsを追加
- ProfileEditFormコンポーネントで編集UI実装
- SettingsPage（/settings）を新規作成
- useFormにinitialFormState変更検知を追加（React公式推奨パターン）
- useUpdateProfileはuseEffect不使用、useMemoで初期値生成

## Test plan
- [x] ビルド成功
- [x] 全438テスト通過
- [x] Lint通過
- [x] useForm: initialFormState動的変更テスト3ケース
- [x] useUpdateProfile: 初期化・同期・バリデーション・送信・リセットテスト10ケース
- [x] ProfileEditForm: Storybook Story 3つ（Default, Loading, FetchError）

Closes #211

Generated with [Claude Code](https://claude.com/claude-code)