### PR TITLE
feat(domain/usecase): AIアドバイスに時間帯考慮を追加

### DIFF
--- a/backend/domain/vo/eaten_at.go
+++ b/backend/domain/vo/eaten_at.go
@@ -1,6 +1,7 @@
 package vo
 
 import (
+	"fmt"
 	"time"
 
 	domainErrors "caltrack/domain/errors"
@@ -80,5 +81,26 @@ func (e EatenAt) MealType() MealType {
 		return MealTypeDinner
 	default:
 		return MealTypeLateNight
+	}
+}
+
+// TimeContext は食事日時からAIアドバイス向けの時間帯コンテキスト文字列を返す
+func (e EatenAt) TimeContext() string {
+	hour := e.value.Hour()
+	mealType := e.MealType()
+
+	switch mealType {
+	case MealTypeBreakfast:
+		return fmt.Sprintf("現在は%d時（%s）の時間帯です。昼食・夕食がまだ残っています。1日の栄養バランスを計画的に摂れるようアドバイスしてください。", hour, mealType.String())
+	case MealTypeLunch:
+		return fmt.Sprintf("現在は%d時（%s）の時間帯です。夕食がまだ残っています。午前中の食事を踏まえて、夕食で補うべき栄養素をアドバイスしてください。", hour, mealType.String())
+	case MealTypeSnack:
+		return fmt.Sprintf("現在は%d時（%s）の時間帯です。夕食がまだ残っています。間食の内容を考慮しつつ、夕食の提案をしてください。", hour, mealType.String())
+	case MealTypeDinner:
+		return fmt.Sprintf("現在は%d時（%s）の時間帯です。今日の食事はほぼ終わりです。1日の振り返りと、明日に向けたアドバイスをしてください。", hour, mealType.String())
+	case MealTypeLateNight:
+		return fmt.Sprintf("現在は%d時（%s）の時間帯です。遅い時間の食事です。消化の良さや翌日への影響を考慮したアドバイスをしてください。", hour, mealType.String())
+	default:
+		return fmt.Sprintf("現在は%d時です。", hour)
 	}
 }

--- a/backend/domain/vo/eaten_at_test.go
+++ b/backend/domain/vo/eaten_at_test.go
@@ -1,6 +1,7 @@
 package vo
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -135,4 +136,51 @@ func TestMealType_String(t *testing.T) {
 			t.Errorf("MealType(99).String() = %v, want %v", got, "不明")
 		}
 	})
+}
+
+func TestEatenAt_TimeContext(t *testing.T) {
+	tests := []struct {
+		name         string
+		hour         int
+		wantContains []string
+	}{
+		{
+			"8時は朝食の時間帯コンテキストを返す",
+			8,
+			[]string{"8時", "朝食", "昼食・夕食がまだ残っています"},
+		},
+		{
+			"12時は昼食の時間帯コンテキストを返す",
+			12,
+			[]string{"12時", "昼食", "夕食がまだ残っています"},
+		},
+		{
+			"15時は間食の時間帯コンテキストを返す",
+			15,
+			[]string{"15時", "間食", "夕食がまだ残っています"},
+		},
+		{
+			"19時は夕食の時間帯コンテキストを返す",
+			19,
+			[]string{"19時", "夕食", "ほぼ終わり"},
+		},
+		{
+			"23時は夜食の時間帯コンテキストを返す",
+			23,
+			[]string{"23時", "夜食", "遅い時間"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eatenAt := ReconstructEatenAt(time.Date(2024, 6, 15, tt.hour, 30, 0, 0, time.UTC))
+			got := eatenAt.TimeContext()
+
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("TimeContext() = %q, want to contain %q", got, want)
+				}
+			}
+		})
+	}
 }

--- a/backend/usecase/service/pfc_analyzer.go
+++ b/backend/usecase/service/pfc_analyzer.go
@@ -12,6 +12,7 @@ type NutritionAdviceInput struct {
 	CurrentCalories int
 	CurrentPfc      vo.Pfc
 	FoodItems       []string
+	TimeContext     string
 }
 
 type PfcAnalyzerLogConfig struct {


### PR DESCRIPTION
## Summary
- EatenAt VOに`TimeContext()`メソッドを追加し、食事時間帯に応じたAI向けコンテキスト文字列を生成
- `NutritionAdviceInput`に`TimeContext`フィールドを追加
- AIプロンプトに【時間帯情報】セクションを追加し、時間帯を考慮したアドバイス生成を実現

## Test plan
- [ ] `TestEatenAt_TimeContext`: 全5時間帯のコンテキスト生成を検証
- [ ] `TestEatenAt_MealType`: 既存の食事タイプ判定テスト（12パターン）が通ること
- [ ] `TestNutritionUsecase_GetAdvice`: 既存のアドバイス取得テスト（8パターン）が通ること
- [ ] `go build ./...` でビルドが通ること
- [ ] `go test ./... -v` で全482テストがパスすること

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)