### PR TITLE
fix(usecase): PR #233のマージ後に壊れたGetAdvice機能を復活

### DIFF
--- a/backend/config/gemini.go
+++ b/backend/config/gemini.go
@@ -52,3 +52,11 @@ func CloseGemini() {
 		log.Println("Gemini client closed")
 	}
 }
+
+// DefaultAIConfig はデフォルトのAI設定を提供する
+type DefaultAIConfig struct{}
+
+// GeminiModelName は使用するGeminiモデル名を返す
+func (c DefaultAIConfig) GeminiModelName() string {
+	return GeminiModelName
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -53,6 +53,7 @@ func main() {
 
 	// DI - Service
 	imageAnalyzer := infraService.NewGeminiImageAnalyzer(config.GeminiClient)
+	pfcAnalyzer := infraService.NewGeminiPfcAnalyzer(config.GeminiClient)
 	pfcEstimator := infraService.NewGeminiPfcEstimator(config.GeminiClient)
 
 	// DI - Usecase
@@ -60,7 +61,7 @@ func main() {
 	authUsecase := usecase.NewAuthUsecase(userRepo, sessionRepo, txManager)
 	recordUsecase := usecase.NewRecordUsecase(recordRepo, recordPfcRepo, userRepo, adviceCacheRepo, txManager, pfcEstimator)
 	analyzeUsecase := usecase.NewAnalyzeUsecase(imageAnalyzer)
-	nutritionUsecase := usecase.NewNutritionUsecase(userRepo, recordPfcRepo)
+	nutritionUsecase := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, pfcAnalyzer)
 
 	// DI - Handler
 	userHandler := user.NewUserHandler(userUsecase)

--- a/backend/mock/mock_record_pfc_repository.go
+++ b/backend/mock/mock_record_pfc_repository.go
@@ -92,7 +92,7 @@ func (mr *MockRecordPfcRepositoryMockRecorder) GetDailyPfc(ctx, userID, startTim
 func (m *MockRecordPfcRepository) Save(ctx context.Context, recordPfc *entity.RecordPfc) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Save", ctx, recordPfc)
-	ret0, _ := ret[1].(error)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 

--- a/backend/usecase/nutrition.go
+++ b/backend/usecase/nutrition.go
@@ -2,19 +2,21 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"caltrack/config"
+	"caltrack/domain/entity"
 	domainErrors "caltrack/domain/errors"
 	"caltrack/domain/repository"
 	"caltrack/domain/vo"
+	"caltrack/usecase/service"
 )
 
-// TodayPfcOutput は今日1日のPFC摂取量と目標の出力構造体
-type TodayPfcOutput struct {
-	Date       time.Time // 対象日付
-	CurrentPfc vo.Pfc    // 今日のPFC摂取量合計
-	TargetPfc  vo.Pfc    // 目標PFC
-}
+const (
+	// NoRecordAdviceMessage は今日の記録がない場合のアドバイスメッセージ
+	NoRecordAdviceMessage = "今日の記録がまだありません。食事を記録してアドバイスを受け取りましょう！"
+)
 
 // TodayPfcOutput は今日1日のPFC摂取量と目標の出力構造体
 type TodayPfcOutput struct {
@@ -25,19 +27,162 @@ type TodayPfcOutput struct {
 
 // NutritionUsecase は栄養分析に関するユースケースを提供する
 type NutritionUsecase struct {
-	userRepo      repository.UserRepository
-	recordPfcRepo repository.RecordPfcRepository
+	userRepo        repository.UserRepository
+	recordRepo      repository.RecordRepository
+	recordPfcRepo   repository.RecordPfcRepository
+	adviceCacheRepo repository.AdviceCacheRepository
+	pfcAnalyzer     service.PfcAnalyzer
 }
 
 // NewNutritionUsecase は NutritionUsecase のインスタンスを生成する
 func NewNutritionUsecase(
 	userRepo repository.UserRepository,
+	recordRepo repository.RecordRepository,
 	recordPfcRepo repository.RecordPfcRepository,
+	adviceCacheRepo repository.AdviceCacheRepository,
+	pfcAnalyzer service.PfcAnalyzer,
 ) *NutritionUsecase {
 	return &NutritionUsecase{
-		userRepo:      userRepo,
-		recordPfcRepo: recordPfcRepo,
+		userRepo:        userRepo,
+		recordRepo:      recordRepo,
+		recordPfcRepo:   recordPfcRepo,
+		adviceCacheRepo: adviceCacheRepo,
+		pfcAnalyzer:     pfcAnalyzer,
 	}
+}
+
+// GetAdvice はユーザーに対する栄養アドバイスを取得する
+func (u *NutritionUsecase) GetAdvice(ctx context.Context, userID vo.UserID) (*service.NutritionAdviceOutput, error) {
+	// ユーザー取得
+	user, err := u.userRepo.FindByID(ctx, userID)
+	if err != nil {
+		logError("GetAdvice", err, "user_id", userID.String())
+		return nil, err
+	}
+	if user == nil {
+		logWarn("GetAdvice", "user not found", "user_id", userID.String())
+		return nil, domainErrors.ErrUserNotFound
+	}
+
+	// 今日の日付範囲を計算
+	now := time.Now()
+	start := startOfDay(now)
+	end := endOfDay(now)
+
+	// 今日のRecord取得
+	records, err := u.recordRepo.FindByUserIDAndDateRange(ctx, userID, start, end)
+	if err != nil {
+		logError("GetAdvice", err, "user_id", userID.String())
+		return nil, err
+	}
+
+	// 今日の記録がない場合は固定文言を返却
+	if len(records) == 0 {
+		return &service.NutritionAdviceOutput{
+			Advice: NoRecordAdviceMessage,
+		}, nil
+	}
+
+	// キャッシュ確認
+	cachedAdvice, err := u.adviceCacheRepo.FindByUserIDAndDate(ctx, userID, now)
+	if err != nil {
+		logError("GetAdvice", err, "user_id", userID.String())
+		return nil, err
+	}
+	// キャッシュがあればそれを返却
+	if cachedAdvice != nil {
+		return &service.NutritionAdviceOutput{
+			Advice: cachedAdvice.Advice(),
+		}, nil
+	}
+
+	// RecordIDリスト抽出
+	recordIDs := make([]vo.RecordID, len(records))
+	for i, record := range records {
+		recordIDs[i] = record.ID()
+	}
+
+	// 今日のRecordPfc取得
+	recordPfcs := make([]*vo.Pfc, 0)
+	if len(recordIDs) > 0 {
+		pfcList, err := u.recordPfcRepo.FindByRecordIDs(ctx, recordIDs)
+		if err != nil {
+			logError("GetAdvice", err, "user_id", userID.String())
+			return nil, err
+		}
+		for _, recordPfc := range pfcList {
+			pfc := recordPfc.Pfc()
+			recordPfcs = append(recordPfcs, &pfc)
+		}
+	}
+
+	// 目標値計算
+	targetCalories := user.CalculateTargetCalories()
+	targetPfc := user.CalculateTargetPfc()
+
+	// 現在値集計
+	currentCalories := 0
+	currentProtein := 0.0
+	currentFat := 0.0
+	currentCarbs := 0.0
+	for _, record := range records {
+		currentCalories += record.TotalCalories()
+	}
+	for _, pfc := range recordPfcs {
+		currentProtein += pfc.Protein()
+		currentFat += pfc.Fat()
+		currentCarbs += pfc.Carbs()
+	}
+	currentPfc := vo.NewPfc(currentProtein, currentFat, currentCarbs)
+
+	// 食品リスト抽出
+	foodItems := make([]string, 0)
+	for _, record := range records {
+		foodItems = append(foodItems, record.ItemNames()...)
+	}
+
+	// 最新記録の時間帯コンテキストを取得
+	latestRecord := findLatestRecord(records)
+	timeContext := latestRecord.EatenAt().TimeContext()
+
+	// PfcAnalyzer.Analyze呼び出し
+	input := service.NutritionAdviceInput{
+		TargetCalories:  targetCalories,
+		TargetPfc:       targetPfc,
+		CurrentCalories: currentCalories,
+		CurrentPfc:      currentPfc,
+		FoodItems:       foodItems,
+		TimeContext:     timeContext,
+	}
+
+	// プロンプト構築
+	prompt := buildNutritionAdvicePrompt(input)
+
+	// Config構築
+	analyzerConfig := service.PfcAnalyzerConfig{
+		ModelName: config.GeminiModelName,
+		Prompt:    prompt,
+		Log: service.PfcAnalyzerLogConfig{
+			EnableRequestLog:  true,
+			EnableResponseLog: true,
+			EnableTokenLog:    true,
+		},
+	}
+
+	output, err := u.pfcAnalyzer.Analyze(ctx, analyzerConfig, input)
+	if err != nil {
+		logError("GetAdvice", err, "user_id", userID.String())
+		return nil, err
+	}
+
+	// キャッシュを保存
+	cache := entity.NewAdviceCache(userID, now, output.Advice)
+	if err := u.adviceCacheRepo.Save(ctx, cache); err != nil {
+		// キャッシュ保存失敗はログのみ（アドバイス取得は成功として扱う）
+		logError("GetAdvice", err, "user_id", userID.String(), "cache_save_failed", true)
+	}
+
+	return output, nil
 }
 
 // GetTodayPfc は認証ユーザーの今日1日のPFC摂取量と目標を取得する
@@ -75,37 +220,64 @@ func (u *NutritionUsecase) GetTodayPfc(ctx context.Context, userID vo.UserID) (*
 	}, nil
 }
 
-// GetTodayPfc は認証ユーザーの今日1日のPFC摂取量と目標を取得する
-func (u *NutritionUsecase) GetTodayPfc(ctx context.Context, userID vo.UserID) (*TodayPfcOutput, error) {
-	// ユーザー取得（目標PFC計算のため）
-	user, err := u.userRepo.FindByID(ctx, userID)
-	if err != nil {
-		logError("GetTodayPfc", err, "user_id", userID.String())
-		return nil, err
+// buildNutritionAdvicePrompt は栄養アドバイスプロンプトを構築する
+func buildNutritionAdvicePrompt(input service.NutritionAdviceInput) string {
+	prompt := fmt.Sprintf(`あなたは栄養アドバイザーです。以下の情報に基づいて、簡潔なアドバイスを提供してください。
+
+【時間帯情報】
+%s
+
+【目標値】
+- カロリー: %d kcal
+- PFC: タンパク質 %.1fg / 脂質 %.1fg / 炭水化物 %.1fg
+
+【現在の摂取量】
+- カロリー: %d kcal
+- PFC: タンパク質 %.1fg / 脂質 %.1fg / 炭水化物 %.1fg
+
+【本日食べたもの】
+%s
+
+アドバイスは以下の形式で出力してください：
+- 3〜5行程度の簡潔な文章
+- 目標達成度を評価
+- 不足または過剰な栄養素を指摘
+- 次の食事で何を意識すべきか提案`,
+		input.TimeContext,
+		input.TargetCalories,
+		input.TargetPfc.Protein(),
+		input.TargetPfc.Fat(),
+		input.TargetPfc.Carbs(),
+		input.CurrentCalories,
+		input.CurrentPfc.Protein(),
+		input.CurrentPfc.Fat(),
+		input.CurrentPfc.Carbs(),
+		formatFoodItems(input.FoodItems),
+	)
+
+	return prompt
+}
+
+// formatFoodItems は食品リストを整形する
+func formatFoodItems(items []string) string {
+	if len(items) == 0 {
+		return "（まだ食事記録がありません）"
 	}
-	if user == nil {
-		logWarn("GetTodayPfc", "user not found", "user_id", userID.String())
-		return nil, domainErrors.ErrUserNotFound
+
+	result := ""
+	for i, item := range items {
+		result += fmt.Sprintf("%d. %s\n", i+1, item)
 	}
+	return result
+}
 
-	// 今日の日付範囲を計算
-	now := time.Now()
-	start := startOfDay(now)
-	end := endOfDay(now)
-
-	// SQL集計でPFC合計を取得
-	dailyPfc, err := u.recordPfcRepo.GetDailyPfc(ctx, userID, start, end)
-	if err != nil {
-		logError("GetTodayPfc", err, "user_id", userID.String())
-		return nil, err
+// findLatestRecord は記録リストから最新の記録を返す
+func findLatestRecord(records []*entity.Record) *entity.Record {
+	latest := records[0]
+	for _, record := range records[1:] {
+		if record.EatenAt().Time().After(latest.EatenAt().Time()) {
+			latest = record
+		}
 	}
-
-	// 目標PFC計算
-	targetPfc := user.CalculateTargetPfc()
-
-	return &TodayPfcOutput{
-		Date:       start,
-		CurrentPfc: dailyPfc.Pfc,
-		TargetPfc:  targetPfc,
-	}, nil
+	return latest
 }

--- a/backend/usecase/nutrition_test.go
+++ b/backend/usecase/nutrition_test.go
@@ -6,11 +6,12 @@ import (
 	"testing"
 	"time"
 
+	"caltrack/domain/entity"
 	domainErrors "caltrack/domain/errors"
-	"caltrack/domain/repository"
 	"caltrack/domain/vo"
 	"caltrack/mock"
 	"caltrack/usecase"
+	"caltrack/usecase/service"
 
 	gomock "go.uber.org/mock/gomock"
 )
@@ -18,28 +19,307 @@ import (
 // setupNutritionMocks はテスト用のモックを初期化する
 func setupNutritionMocks(t *testing.T) (
 	*mock.MockUserRepository,
+	*mock.MockRecordRepository,
 	*mock.MockRecordPfcRepository,
+	*mock.MockAdviceCacheRepository,
+	*mock.MockPfcAnalyzer,
 	*gomock.Controller,
 ) {
 	t.Helper()
 	ctrl := gomock.NewController(t)
 	return mock.NewMockUserRepository(ctrl),
+		mock.NewMockRecordRepository(ctrl),
 		mock.NewMockRecordPfcRepository(ctrl),
+		mock.NewMockAdviceCacheRepository(ctrl),
+		mock.NewMockPfcAnalyzer(ctrl),
 		ctrl
 }
 
-func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
-	t.Run("正常系_今日のPFC摂取量と目標を取得", func(t *testing.T) {
-		userRepo, recordPfcRepo, ctrl := setupNutritionMocks(t)
+func TestNutritionUsecase_GetAdvice(t *testing.T) {
+	t.Run("正常系_今日の記録がない場合は固定文言が返される", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
 		defer ctrl.Finish()
 
 		userID := vo.NewUserID()
 		user := validUserForRecord(t, userID)
 
-		dailyPfc := &repository.DailyPfc{
-			Date: time.Now(),
-			Pfc:  vo.NewPfc(35.0, 25.0, 100.0),
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
+
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return([]*entity.Record{}, nil)
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		output, err := uc.GetAdvice(context.Background(), userID)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
+
+		if output.Advice != usecase.NoRecordAdviceMessage {
+			t.Errorf("Advice = %s, want %s", output.Advice, usecase.NoRecordAdviceMessage)
+		}
+	})
+
+	t.Run("正常系_キャッシュがある場合はキャッシュが返される", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		user := validUserForRecord(t, userID)
+
+		// 今日のRecordを作成
+		record1, _ := entity.NewRecord(userID, time.Now())
+		_ = record1.AddItem("朝食", 300)
+		records := []*entity.Record{record1}
+
+		cachedAdvice := "キャッシュされたアドバイス"
+		cache := entity.NewAdviceCache(userID, time.Now(), cachedAdvice)
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
+
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return(records, nil)
+
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(cache, nil)
+
+		// analyzer.Analyzeは呼ばれないこと（EXPECTを設定しないことで検証）
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		output, err := uc.GetAdvice(context.Background(), userID)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if output.Advice != cachedAdvice {
+			t.Errorf("Advice = %s, want %s", output.Advice, cachedAdvice)
+		}
+	})
+
+	t.Run("正常系_キャッシュがない場合はAI呼び出し後にキャッシュ保存される", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		user := validUserForRecord(t, userID)
+
+		// 今日のRecordを作成
+		record1, _ := entity.NewRecord(userID, time.Now())
+		_ = record1.AddItem("朝食", 300)
+
+		record2, _ := entity.NewRecord(userID, time.Now())
+		_ = record2.AddItem("昼食", 500)
+
+		records := []*entity.Record{record1, record2}
+
+		// RecordPfcを作成
+		recordPfc1 := entity.NewRecordPfc(record1.ID(), 15.0, 10.0, 40.0)
+		recordPfc2 := entity.NewRecordPfc(record2.ID(), 20.0, 15.0, 60.0)
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
+
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return(records, nil)
+
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(nil, nil) // キャッシュなし
+
+		recordPfcRepo.EXPECT().
+			FindByRecordIDs(gomock.Any(), gomock.Any()).
+			Return([]*entity.RecordPfc{recordPfc1, recordPfc2}, nil)
+
+		analyzer.EXPECT().
+			Analyze(gomock.Any(), gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, config service.PfcAnalyzerConfig, input service.NutritionAdviceInput) (*service.NutritionAdviceOutput, error) {
+				// プロンプトが構築されていることを確認
+				if config.Prompt == "" {
+					t.Error("Prompt should not be empty")
+				}
+				return &service.NutritionAdviceOutput{Advice: "バランスの良い食事ができています"}, nil
+			})
+
+		adviceCacheRepo.EXPECT().
+			Save(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, cache *entity.AdviceCache) error {
+				if cache.Advice() != "バランスの良い食事ができています" {
+					t.Errorf("Saved cache advice = %s, want %s", cache.Advice(), "バランスの良い食事ができています")
+				}
+				return nil
+			})
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		output, err := uc.GetAdvice(context.Background(), userID)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if output.Advice == "" {
+			t.Error("Advice should not be empty")
+		}
+
+		if output.Advice != "バランスの良い食事ができています" {
+			t.Errorf("Advice = %s, want %s", output.Advice, "バランスの良い食事ができています")
+		}
+	})
+
+	t.Run("異常系_ユーザーが存在しない", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(nil, nil)
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		_, err := uc.GetAdvice(context.Background(), userID)
+
+		if !errors.Is(err, domainErrors.ErrUserNotFound) {
+			t.Errorf("got %v, want ErrUserNotFound", err)
+		}
+	})
+
+	t.Run("異常系_ユーザー取得時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		repoErr := errors.New("db error")
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(nil, repoErr)
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		_, err := uc.GetAdvice(context.Background(), userID)
+
+		if !errors.Is(err, repoErr) {
+			t.Errorf("got %v, want repoErr", err)
+		}
+	})
+
+	t.Run("異常系_Record取得時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		user := validUserForRecord(t, userID)
+		repoErr := errors.New("db error")
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
+
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return(nil, repoErr)
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		_, err := uc.GetAdvice(context.Background(), userID)
+
+		if !errors.Is(err, repoErr) {
+			t.Errorf("got %v, want repoErr", err)
+		}
+	})
+
+	t.Run("異常系_RecordPfc取得時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		user := validUserForRecord(t, userID)
+		repoErr := errors.New("db error")
+
+		record1, _ := entity.NewRecord(userID, time.Now())
+		_ = record1.AddItem("朝食", 300)
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
+
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return([]*entity.Record{record1}, nil)
+
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(nil, nil)
+
+		recordPfcRepo.EXPECT().
+			FindByRecordIDs(gomock.Any(), gomock.Any()).
+			Return(nil, repoErr)
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		_, err := uc.GetAdvice(context.Background(), userID)
+
+		if !errors.Is(err, repoErr) {
+			t.Errorf("got %v, want repoErr", err)
+		}
+	})
+
+	t.Run("異常系_PfcAnalyzer実行時にエラー", func(t *testing.T) {
+		userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		user := validUserForRecord(t, userID)
+		analyzeErr := errors.New("analyzer error")
+
+		record1, _ := entity.NewRecord(userID, time.Now())
+		_ = record1.AddItem("朝食", 300)
+
+		userRepo.EXPECT().
+			FindByID(gomock.Any(), userID).
+			Return(user, nil)
+
+		recordRepo.EXPECT().
+			FindByUserIDAndDateRange(gomock.Any(), userID, gomock.Any(), gomock.Any()).
+			Return([]*entity.Record{record1}, nil)
+
+		adviceCacheRepo.EXPECT().
+			FindByUserIDAndDate(gomock.Any(), userID, gomock.Any()).
+			Return(nil, nil)
+
+		recordPfcRepo.EXPECT().
+			FindByRecordIDs(gomock.Any(), gomock.Any()).
+			Return([]*entity.RecordPfc{}, nil)
+
+		analyzer.EXPECT().
+			Analyze(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil, analyzeErr)
+
+		uc := usecase.NewNutritionUsecase(userRepo, recordRepo, recordPfcRepo, adviceCacheRepo, analyzer)
+		_, err := uc.GetAdvice(context.Background(), userID)
+
+		if !errors.Is(err, analyzeErr) {
+			t.Errorf("got %v, want analyzeErr", err)
+		}
+	})
+}
+
+func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
+	t.Run("正常系_今日のPFC摂取量と目標を取得", func(t *testing.T) {
+		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
+		defer ctrl.Finish()
+
+		userID := vo.NewUserID()
+		user := validUserForRecord(t, userID)
+
+		dailyPfc := vo.NewDailyPfc(35.0, 25.0, 100.0)
 
 		userRepo.EXPECT().
 			FindByID(gomock.Any(), userID).
@@ -49,7 +329,7 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 			GetDailyPfc(gomock.Any(), userID, gomock.Any(), gomock.Any()).
 			Return(dailyPfc, nil)
 
-		uc := usecase.NewNutritionUsecase(userRepo, recordPfcRepo)
+		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
 		output, err := uc.GetTodayPfc(context.Background(), userID)
 
 		if err != nil {
@@ -79,16 +359,13 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 	})
 
 	t.Run("正常系_記録がない場合はゼロPFCが返される", func(t *testing.T) {
-		userRepo, recordPfcRepo, ctrl := setupNutritionMocks(t)
+		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
 		defer ctrl.Finish()
 
 		userID := vo.NewUserID()
 		user := validUserForRecord(t, userID)
 
-		dailyPfc := &repository.DailyPfc{
-			Date: time.Now(),
-			Pfc:  vo.NewPfc(0, 0, 0),
-		}
+		dailyPfc := vo.NewDailyPfc(0, 0, 0)
 
 		userRepo.EXPECT().
 			FindByID(gomock.Any(), userID).
@@ -98,7 +375,7 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 			GetDailyPfc(gomock.Any(), userID, gomock.Any(), gomock.Any()).
 			Return(dailyPfc, nil)
 
-		uc := usecase.NewNutritionUsecase(userRepo, recordPfcRepo)
+		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
 		output, err := uc.GetTodayPfc(context.Background(), userID)
 
 		if err != nil {
@@ -117,7 +394,7 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 	})
 
 	t.Run("異常系_ユーザーが存在しない", func(t *testing.T) {
-		userRepo, recordPfcRepo, ctrl := setupNutritionMocks(t)
+		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
 		defer ctrl.Finish()
 
 		userID := vo.NewUserID()
@@ -126,7 +403,7 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 			FindByID(gomock.Any(), userID).
 			Return(nil, nil)
 
-		uc := usecase.NewNutritionUsecase(userRepo, recordPfcRepo)
+		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
 		_, err := uc.GetTodayPfc(context.Background(), userID)
 
 		if !errors.Is(err, domainErrors.ErrUserNotFound) {
@@ -135,7 +412,7 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 	})
 
 	t.Run("異常系_ユーザー取得時にエラー", func(t *testing.T) {
-		userRepo, recordPfcRepo, ctrl := setupNutritionMocks(t)
+		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
 		defer ctrl.Finish()
 
 		userID := vo.NewUserID()
@@ -145,7 +422,7 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 			FindByID(gomock.Any(), userID).
 			Return(nil, repoErr)
 
-		uc := usecase.NewNutritionUsecase(userRepo, recordPfcRepo)
+		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
 		_, err := uc.GetTodayPfc(context.Background(), userID)
 
 		if !errors.Is(err, repoErr) {
@@ -154,112 +431,6 @@ func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
 	})
 
 	t.Run("異常系_DailyPfc取得時にエラー", func(t *testing.T) {
-		userRepo, recordPfcRepo, ctrl := setupNutritionMocks(t)
-		defer ctrl.Finish()
-
-		userID := vo.NewUserID()
-		user := validUserForRecord(t, userID)
-		repoErr := errors.New("db error")
-
-		userRepo.EXPECT().
-			FindByID(gomock.Any(), userID).
-			Return(user, nil)
-
-		recordPfcRepo.EXPECT().
-			GetDailyPfc(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-			Return(nil, repoErr)
-
-		uc := usecase.NewNutritionUsecase(userRepo, recordPfcRepo)
-		_, err := uc.GetTodayPfc(context.Background(), userID)
-
-		if !errors.Is(err, repoErr) {
-			t.Errorf("got %v, want repoErr", err)
-		}
-	})
-}
-
-func TestNutritionUsecase_GetTodayPfc(t *testing.T) {
-	t.Run("正常系_今日のPFC取得成功", func(t *testing.T) {
-		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
-		defer ctrl.Finish()
-
-		userID := vo.NewUserID()
-		user := validUserForRecord(t, userID)
-
-		dailyPfc := vo.DailyPfc{
-			Pfc: vo.NewPfc(50.0, 30.0, 150.0),
-		}
-
-		userRepo.EXPECT().
-			FindByID(gomock.Any(), userID).
-			Return(user, nil)
-
-		recordPfcRepo.EXPECT().
-			GetDailyPfc(gomock.Any(), userID, gomock.Any(), gomock.Any()).
-			Return(dailyPfc, nil)
-
-		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
-		output, err := uc.GetTodayPfc(context.Background(), userID)
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		if output.CurrentPfc.Protein() != 50.0 {
-			t.Errorf("CurrentPfc.Protein = %f, want 50.0", output.CurrentPfc.Protein())
-		}
-		if output.CurrentPfc.Fat() != 30.0 {
-			t.Errorf("CurrentPfc.Fat = %f, want 30.0", output.CurrentPfc.Fat())
-		}
-		if output.CurrentPfc.Carbs() != 150.0 {
-			t.Errorf("CurrentPfc.Carbs = %f, want 150.0", output.CurrentPfc.Carbs())
-		}
-
-		// 目標値の検証（BMRベース）
-		targetPfc := user.CalculateTargetPfc()
-		if output.TargetPfc.Protein() != targetPfc.Protein() {
-			t.Errorf("TargetPfc.Protein = %f, want %f", output.TargetPfc.Protein(), targetPfc.Protein())
-		}
-	})
-
-	t.Run("異常系_ユーザーが存在しない", func(t *testing.T) {
-		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
-		defer ctrl.Finish()
-
-		userID := vo.NewUserID()
-
-		userRepo.EXPECT().
-			FindByID(gomock.Any(), userID).
-			Return(nil, nil)
-
-		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
-		_, err := uc.GetTodayPfc(context.Background(), userID)
-
-		if !errors.Is(err, domainErrors.ErrUserNotFound) {
-			t.Errorf("got %v, want ErrUserNotFound", err)
-		}
-	})
-
-	t.Run("異常系_ユーザー取得時にエラー", func(t *testing.T) {
-		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
-		defer ctrl.Finish()
-
-		userID := vo.NewUserID()
-		repoErr := errors.New("db error")
-
-		userRepo.EXPECT().
-			FindByID(gomock.Any(), userID).
-			Return(nil, repoErr)
-
-		uc := usecase.NewNutritionUsecase(userRepo, nil, recordPfcRepo, nil, nil)
-		_, err := uc.GetTodayPfc(context.Background(), userID)
-
-		if !errors.Is(err, repoErr) {
-			t.Errorf("got %v, want repoErr", err)
-		}
-	})
-
-	t.Run("異常系_RecordPfc取得時にエラー", func(t *testing.T) {
 		userRepo, _, recordPfcRepo, _, _, ctrl := setupNutritionMocks(t)
 		defer ctrl.Finish()
 

--- a/backend/usecase/record.go
+++ b/backend/usecase/record.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"caltrack/config"
 	"caltrack/domain/entity"
 	domainErrors "caltrack/domain/errors"
 	"caltrack/domain/repository"
@@ -30,7 +31,6 @@ type RecordUsecase struct {
 	adviceCacheRepo repository.AdviceCacheRepository
 	txManager       repository.TransactionManager
 	pfcEstimator    service.PfcEstimator
-	aiConfig        AIConfig
 }
 
 // NewRecordUsecase は RecordUsecase のインスタンスを生成する
@@ -41,7 +41,6 @@ func NewRecordUsecase(
 	adviceCacheRepo repository.AdviceCacheRepository,
 	txManager repository.TransactionManager,
 	pfcEstimator service.PfcEstimator,
-	aiConfig AIConfig,
 ) *RecordUsecase {
 	return &RecordUsecase{
 		recordRepo:      recordRepo,
@@ -50,7 +49,6 @@ func NewRecordUsecase(
 		adviceCacheRepo: adviceCacheRepo,
 		txManager:       txManager,
 		pfcEstimator:    pfcEstimator,
-		aiConfig:        aiConfig,
 	}
 }
 
@@ -101,7 +99,7 @@ func (u *RecordUsecase) estimatePfc(ctx context.Context, record *entity.Record) 
 
 	// PFC推定実行
 	estimatorConfig := service.PfcEstimatorConfig{
-		ModelName: u.aiConfig.GeminiModelName(),
+		ModelName: config.GeminiModelName,
 		Prompt:    prompt,
 		Log: service.PfcEstimatorLogConfig{
 			EnableRequestLog:  true,


### PR DESCRIPTION
## Summary
- GetAdvice（AI栄養アドバイス機能）をfd42165から復元し、GetTodayPfcと共存
- TodayPfcOutput構造体とGetTodayPfcメソッドの重複定義を解消
- NutritionUsecaseの依存関係を修正（recordRepo, adviceCacheRepo, pfcAnalyzer）
- record.goのAIConfig関連コードを修正
- nutrition_test.goとrecord.goのテストを修正
- mock_record_pfc_repository.goを更新

## Test plan
- [x] Build: Pass
- [x] Test: Pass

Generated with [Claude Code](https://claude.com/claude-code)