### PR TITLE
feat(frontend): PFC機能改善 - VO作成・UIデザイン改善・Storybook追加

### DIFF
--- a/.claude/rules/frontend-layer.md
+++ b/.claude/rules/frontend-layer.md
@@ -196,11 +196,66 @@ function validate(form: FormState): FormErrors {
 
 ## Storybook
 
-**コンポーネント実装時は必ずStoryを作成すること**
+**コンポーネント実装時は必ずStoryファイルを作成すること（省略不可）**
+
+### 基本ルール
 
 - ファイル: `{Component}.stories.tsx`
 - 配置: コンポーネントと同じディレクトリ
-- 必須Story: Default, Loading（該当時）, Empty（該当時）
+- import: `import type { Meta, StoryObj } from "@storybook/react-vite"`
+
+### title命名規則
+
+| 配置先 | title |
+|--------|-------|
+| `features/{feature}/components/` | `Features/{Feature}/{Component}` |
+| `components/ui/` | `UI/{Component}` |
+| `components/` | `Components/{Component}` |
+| `pages/` | `Pages/{Page}` |
+
+### チェックリスト
+
+コンポーネントの特性に応じて、以下のStoryが必要か確認すること:
+
+| Story | 条件 | 必須度 |
+|-------|------|--------|
+| Default | 常に | **必須** |
+| Loading | isLoading propsがある場合 | **必須** |
+| Empty | データなし状態がある場合 | **必須** |
+| Error | error propsがある場合 | **必須** |
+| バリエーション | 状態違いが意味を持つ場合 | 推奨 |
+
+### テンプレート
+
+```tsx
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ComponentName } from "./ComponentName";
+
+const meta: Meta<typeof ComponentName> = {
+  title: "Features/{Feature}/{ComponentName}",
+  component: ComponentName,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ComponentName>;
+
+export const Default: Story = {
+  args: {
+    // デフォルトprops
+  },
+};
+```
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-progress": "^1.1.8",
         "axios": "^1.13.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -1695,6 +1696,86 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+      "integrity": "sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-progress": "^1.1.8",
     "axios": "^1.13.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",

--- a/frontend/src/components/ui/progress.tsx
+++ b/frontend/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root> & {
+    indicatorClassName?: string
+  }
+>(({ className, value, indicatorClassName, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-secondary",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className={cn("h-full w-full flex-1 bg-primary transition-all", indicatorClassName)}
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/frontend/src/domain/valueObjects/index.ts
+++ b/frontend/src/domain/valueObjects/index.ts
@@ -10,3 +10,4 @@ export * from "./itemName";
 export * from "./calories";
 export * from "./eatenAt";
 export * from "./imageFile";
+export * from "./pfcNutrient";

--- a/frontend/src/domain/valueObjects/pfcNutrient.test.ts
+++ b/frontend/src/domain/valueObjects/pfcNutrient.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { newPfcNutrient, PFC_NUTRIENT_OPTIONS } from "./pfcNutrient";
+
+describe("PfcNutrient", () => {
+  describe("正常系", () => {
+    it("protein を正しく作成できる", () => {
+      const result = newPfcNutrient("protein");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe("protein");
+      }
+    });
+
+    it("fat を正しく作成できる", () => {
+      const result = newPfcNutrient("fat");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe("fat");
+      }
+    });
+
+    it("carbs を正しく作成できる", () => {
+      const result = newPfcNutrient("carbs");
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.value.value).toBe("carbs");
+      }
+    });
+  });
+
+  describe("getLabel", () => {
+    it('protein は "タンパク質" を返す', () => {
+      const result = newPfcNutrient("protein");
+      if (result.ok) {
+        expect(result.value.getLabel()).toBe("タンパク質");
+      }
+    });
+
+    it('fat は "脂質" を返す', () => {
+      const result = newPfcNutrient("fat");
+      if (result.ok) {
+        expect(result.value.getLabel()).toBe("脂質");
+      }
+    });
+
+    it('carbs は "炭水化物" を返す', () => {
+      const result = newPfcNutrient("carbs");
+      if (result.ok) {
+        expect(result.value.getLabel()).toBe("炭水化物");
+      }
+    });
+  });
+
+  describe("getShortLabel", () => {
+    it('protein は "P" を返す', () => {
+      const result = newPfcNutrient("protein");
+      if (result.ok) {
+        expect(result.value.getShortLabel()).toBe("P");
+      }
+    });
+
+    it('fat は "F" を返す', () => {
+      const result = newPfcNutrient("fat");
+      if (result.ok) {
+        expect(result.value.getShortLabel()).toBe("F");
+      }
+    });
+
+    it('carbs は "C" を返す', () => {
+      const result = newPfcNutrient("carbs");
+      if (result.ok) {
+        expect(result.value.getShortLabel()).toBe("C");
+      }
+    });
+  });
+
+  describe("異常系", () => {
+    it("空文字はエラーを返す", () => {
+      const result = newPfcNutrient("");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("PFC_NUTRIENT_INVALID");
+      }
+    });
+
+    it("unknown はエラーを返す", () => {
+      const result = newPfcNutrient("unknown");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("PFC_NUTRIENT_INVALID");
+      }
+    });
+
+    it("大文字 PROTEIN はエラーを返す", () => {
+      const result = newPfcNutrient("PROTEIN");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("PFC_NUTRIENT_INVALID");
+      }
+    });
+
+    it("日本語 タンパク質 はエラーを返す", () => {
+      const result = newPfcNutrient("タンパク質");
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error.code).toBe("PFC_NUTRIENT_INVALID");
+      }
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値同士は true を返す", () => {
+      const protein1 = newPfcNutrient("protein");
+      const protein2 = newPfcNutrient("protein");
+      if (protein1.ok && protein2.ok) {
+        expect(protein1.value.equals(protein2.value)).toBe(true);
+      }
+    });
+
+    it("異なる値同士は false を返す", () => {
+      const protein = newPfcNutrient("protein");
+      const fat = newPfcNutrient("fat");
+      if (protein.ok && fat.ok) {
+        expect(protein.value.equals(fat.value)).toBe(false);
+      }
+    });
+  });
+
+  describe("PFC_NUTRIENT_OPTIONS", () => {
+    it("3つの選択肢が存在する", () => {
+      expect(PFC_NUTRIENT_OPTIONS).toHaveLength(3);
+      expect(PFC_NUTRIENT_OPTIONS.map((opt) => opt.value)).toEqual([
+        "protein",
+        "fat",
+        "carbs",
+      ]);
+    });
+  });
+});

--- a/frontend/src/domain/valueObjects/pfcNutrient.ts
+++ b/frontend/src/domain/valueObjects/pfcNutrient.ts
@@ -1,0 +1,55 @@
+import { Result, ok, err } from "../shared/result";
+import { DomainError, domainError } from "../shared/errors";
+
+export type PfcNutrientValue = "protein" | "fat" | "carbs";
+
+export type PfcNutrientErrorCode = "PFC_NUTRIENT_INVALID";
+
+export type PfcNutrientError = DomainError<PfcNutrientErrorCode>;
+
+export type PfcNutrient = Readonly<{
+  value: PfcNutrientValue;
+  getLabel: () => string;
+  getShortLabel: () => string;
+  equals: (other: PfcNutrient) => boolean;
+}>;
+
+/** 選択肢の型 */
+export type PfcNutrientOption = {
+  value: PfcNutrientValue;
+  label: string;
+  shortLabel: string;
+};
+
+/** PFC栄養素の選択肢（UI用） */
+export const PFC_NUTRIENT_OPTIONS: PfcNutrientOption[] = [
+  { value: "protein", label: "タンパク質", shortLabel: "P" },
+  { value: "fat", label: "脂質", shortLabel: "F" },
+  { value: "carbs", label: "炭水化物", shortLabel: "C" },
+];
+
+const VALID_PFC_NUTRIENTS: PfcNutrientValue[] = PFC_NUTRIENT_OPTIONS.map(
+  (o) => o.value
+);
+
+const ERROR_MESSAGE_PFC_NUTRIENT_INVALID = "PFC栄養素を選択してください";
+
+export const newPfcNutrient = (
+  value: string
+): Result<PfcNutrient, PfcNutrientError> => {
+  if (!VALID_PFC_NUTRIENTS.includes(value as PfcNutrientValue)) {
+    return err(
+      domainError("PFC_NUTRIENT_INVALID", ERROR_MESSAGE_PFC_NUTRIENT_INVALID)
+    );
+  }
+
+  const option = PFC_NUTRIENT_OPTIONS.find((o) => o.value === value)!;
+
+  const pfcNutrient: PfcNutrient = Object.freeze({
+    value: value as PfcNutrientValue,
+    getLabel: () => option.label,
+    getShortLabel: () => option.shortLabel,
+    equals: (other: PfcNutrient) => value === other.value,
+  });
+  return ok(pfcNutrient);
+};

--- a/frontend/src/features/nutrition/components/PfcProgressCard.stories.tsx
+++ b/frontend/src/features/nutrition/components/PfcProgressCard.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { PfcProgressCard } from "./PfcProgressCard";
+import type { ApiErrorResponse } from "@/lib/api";
+
+const meta: Meta<typeof PfcProgressCard> = {
+  title: "Features/Nutrition/PfcProgressCard",
+  component: PfcProgressCard,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[720px] p-4">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof PfcProgressCard>;
+
+/** デフォルト表示（通常状態 0-79%） */
+export const Default: Story = {
+  args: {
+    data: {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 35.0, fat: 25.0, carbs: 100.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    },
+    isLoading: false,
+    error: null,
+  },
+};
+
+/** 適切状態（80-100%） */
+export const Optimal: Story = {
+  args: {
+    data: {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 100.0, fat: 55.0, carbs: 260.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    },
+    isLoading: false,
+    error: null,
+  },
+};
+
+/** 超過状態（100%超） */
+export const Over: Story = {
+  args: {
+    data: {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 200.0, fat: 100.0, carbs: 500.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    },
+    isLoading: false,
+    error: null,
+  },
+};
+
+/** 混合状態（各栄養素で異なるステータス） */
+export const Mixed: Story = {
+  args: {
+    data: {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 35.0, fat: 55.0, carbs: 500.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    },
+    isLoading: false,
+    error: null,
+  },
+};
+
+/** ローディング状態 */
+export const Loading: Story = {
+  args: {
+    data: null,
+    isLoading: true,
+    error: null,
+  },
+};
+
+/** エラー状態 */
+export const Error: Story = {
+  args: {
+    data: null,
+    isLoading: false,
+    error: {
+      code: "INTERNAL_ERROR",
+      message: "サーバーエラーが発生しました",
+    } as ApiErrorResponse,
+  },
+};
+
+/** データなし */
+export const Empty: Story = {
+  args: {
+    data: null,
+    isLoading: false,
+    error: null,
+  },
+};

--- a/frontend/src/features/nutrition/components/PfcProgressCard.test.tsx
+++ b/frontend/src/features/nutrition/components/PfcProgressCard.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * PfcProgressCard テスト
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PfcProgressCard } from "./PfcProgressCard";
+import type { TodayPfcResponse } from "../hooks/useTodayPfc";
+
+vi.mock("@/features/common/hooks", () => ({
+  useCountUp: ({ end }: { end: number }) => end,
+}));
+
+const mockData: TodayPfcResponse = {
+  date: "2026-02-09T00:00:00Z",
+  current: { protein: 35.0, fat: 25.0, carbs: 100.0 },
+  target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+};
+
+describe("PfcProgressCard", () => {
+  it("PFCデータが正しく表示される", () => {
+    render(<PfcProgressCard data={mockData} isLoading={false} error={null} />);
+    expect(screen.getByText("今日のPFCバランス")).toBeInTheDocument();
+    expect(screen.getByText("タンパク質")).toBeInTheDocument();
+    expect(screen.getByText("脂質")).toBeInTheDocument();
+    expect(screen.getByText("炭水化物")).toBeInTheDocument();
+  });
+
+  it("タンパク質の数値とパーセンテージが正しく表示される", () => {
+    render(<PfcProgressCard data={mockData} isLoading={false} error={null} />);
+    expect(screen.getByText("35g / 120g (29%)")).toBeInTheDocument();
+  });
+
+  it("脂質の数値とパーセンテージが正しく表示される", () => {
+    render(<PfcProgressCard data={mockData} isLoading={false} error={null} />);
+    expect(screen.getByText("25g / 65g (38%)")).toBeInTheDocument();
+  });
+
+  it("炭水化物の数値とパーセンテージが正しく表示される", () => {
+    render(<PfcProgressCard data={mockData} isLoading={false} error={null} />);
+    expect(screen.getByText("100g / 300g (33%)")).toBeInTheDocument();
+  });
+
+  it("進捗バーにaria-labelが設定される", () => {
+    render(<PfcProgressCard data={mockData} isLoading={false} error={null} />);
+    expect(screen.getByLabelText("タンパク質の進捗")).toBeInTheDocument();
+    expect(screen.getByLabelText("脂質の進捗")).toBeInTheDocument();
+    expect(screen.getByLabelText("炭水化物の進捗")).toBeInTheDocument();
+  });
+
+  it("ローディング中はデータが表示されない", () => {
+    render(<PfcProgressCard data={mockData} isLoading={true} error={null} />);
+    expect(screen.queryByText("タンパク質")).not.toBeInTheDocument();
+  });
+
+  it("エラー時はエラーメッセージが表示される", () => {
+    render(
+      <PfcProgressCard
+        data={null}
+        isLoading={false}
+        error={{ code: "INTERNAL_ERROR", message: "Server error" }}
+      />
+    );
+    expect(screen.getByText("PFCデータの取得に失敗しました")).toBeInTheDocument();
+  });
+
+  it("データがない場合は案内メッセージが表示される", () => {
+    render(<PfcProgressCard data={null} isLoading={false} error={null} />);
+    expect(screen.getByText("食事を記録するとPFCバランスが表示されます")).toBeInTheDocument();
+  });
+
+  it("100%超は実際のパーセンテージが表示される", () => {
+    const overData: TodayPfcResponse = {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 200.0, fat: 100.0, carbs: 500.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    };
+    render(<PfcProgressCard data={overData} isLoading={false} error={null} />);
+    expect(screen.getByText("200g / 120g (167%)")).toBeInTheDocument();
+    expect(screen.getByText("100g / 65g (154%)")).toBeInTheDocument();
+    expect(screen.getByText("500g / 300g (167%)")).toBeInTheDocument();
+  });
+
+  it("80-100%でoptimalステータスのスタイルが適用される", () => {
+    const optimalData: TodayPfcResponse = {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 100.0, fat: 55.0, carbs: 250.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    };
+    render(<PfcProgressCard data={optimalData} isLoading={false} error={null} />);
+    // protein: 83%, fat: 85%, carbs: 83% → 全部optimal
+    expect(screen.getByText("100g / 120g (83%)")).toBeInTheDocument();
+    expect(screen.getByText("55g / 65g (85%)")).toBeInTheDocument();
+    expect(screen.getByText("250g / 300g (83%)")).toBeInTheDocument();
+
+    // optimalステータスでtext-green-600が適用されること
+    const proteinText = screen.getByText("100g / 120g (83%)");
+    expect(proteinText.className).toContain("text-green-600");
+  });
+
+  it("100%超でoverステータスのスタイルが適用される", () => {
+    const overData: TodayPfcResponse = {
+      date: "2026-02-09T00:00:00Z",
+      current: { protein: 200.0, fat: 100.0, carbs: 500.0 },
+      target: { protein: 120.0, fat: 65.0, carbs: 300.0 },
+    };
+    render(<PfcProgressCard data={overData} isLoading={false} error={null} />);
+
+    // overステータスでtext-red-600が適用されること
+    const proteinText = screen.getByText("200g / 120g (167%)");
+    expect(proteinText.className).toContain("text-red-600");
+  });
+});

--- a/frontend/src/features/nutrition/components/PfcProgressCard.tsx
+++ b/frontend/src/features/nutrition/components/PfcProgressCard.tsx
@@ -1,0 +1,172 @@
+/**
+ * PfcProgressCard - 今日のPFC摂取量プログレスカード
+ * P(タンパク質)、F(脂質)、C(炭水化物)それぞれの進捗バーを表示する
+ */
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PFC_NUTRIENT_OPTIONS } from "@/domain/valueObjects";
+import { useCountUp } from "@/features/common/hooks";
+import type { ApiErrorResponse } from "@/lib/api";
+import type { TodayPfcResponse } from "../hooks/useTodayPfc";
+
+export type PfcProgressCardProps = {
+  data: TodayPfcResponse | null;
+  isLoading: boolean;
+  error: ApiErrorResponse | null;
+};
+
+/** PFC各栄養素の表示設定 */
+type NutrientConfig = {
+  key: "protein" | "fat" | "carbs";
+  label: string;
+  shortLabel: string;
+  colorClass: string;
+  bgColorClass: string;
+};
+
+const NUTRIENT_CONFIGS: NutrientConfig[] = PFC_NUTRIENT_OPTIONS.map((opt) => {
+  const colors: Record<string, { colorClass: string; bgColorClass: string }> = {
+    protein: { colorClass: "bg-blue-500", bgColorClass: "bg-blue-100" },
+    fat: { colorClass: "bg-amber-500", bgColorClass: "bg-amber-100" },
+    carbs: { colorClass: "bg-emerald-500", bgColorClass: "bg-emerald-100" },
+  };
+  return {
+    key: opt.value,
+    label: opt.label,
+    shortLabel: opt.shortLabel,
+    ...colors[opt.value],
+  };
+});
+
+/** 進捗ステータス */
+type ProgressStatus = "normal" | "optimal" | "over";
+
+/** 進捗率からステータスを判定する */
+function getProgressStatus(rawPercentage: number): ProgressStatus {
+  if (rawPercentage > 100) return "over";
+  if (rawPercentage >= 80) return "optimal";
+  return "normal";
+}
+
+/**
+ * 単一栄養素の進捗バー表示コンポーネント
+ */
+function NutrientProgressBar({
+  config,
+  current,
+  target,
+}: {
+  config: NutrientConfig;
+  current: number;
+  target: number;
+}) {
+  const rawPercentage = target > 0 ? Math.round((current / target) * 100) : 0;
+  const clampedPercentage = Math.min(rawPercentage, 100);
+  const status = getProgressStatus(rawPercentage);
+
+  const animatedCurrent = useCountUp({ end: Math.round(current), duration: 1000, startOnMount: true });
+  const animatedPercentage = useCountUp({ end: rawPercentage, duration: 1000, startOnMount: true });
+
+  // ステータスに応じたスタイル
+  const badgeColorClass = status === "over" ? "bg-red-500" : status === "optimal" ? "bg-green-500" : config.colorClass;
+  const barTrackClass = status === "over" ? "bg-red-100" : status === "optimal" ? "bg-green-100" : config.bgColorClass;
+  const barIndicatorClass = status === "over" ? "bg-red-500" : status === "optimal" ? "bg-green-500" : config.colorClass;
+  const textColorClass = status === "over" ? "text-red-600" : status === "optimal" ? "text-green-600" : "text-muted-foreground";
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold text-white ${badgeColorClass}`}
+          >
+            {config.shortLabel}
+          </span>
+          <span className="text-sm font-medium">{config.label}</span>
+        </div>
+        <span className={`text-sm tabular-nums ${textColorClass}`}>
+          {animatedCurrent}g / {Math.round(target)}g ({animatedPercentage}%)
+        </span>
+      </div>
+      <Progress
+        value={clampedPercentage}
+        className={`h-3 ${barTrackClass}`}
+        indicatorClassName={barIndicatorClass}
+        aria-label={`${config.label}の進捗`}
+      />
+    </div>
+  );
+}
+
+/**
+ * PfcProgressCard - PFC摂取量プログレスカード
+ */
+export function PfcProgressCard({ data, isLoading, error }: PfcProgressCardProps) {
+  if (isLoading) {
+    return (
+      <Card className="opacity-0 animate-fade-in-up">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">今日のPFCバランス</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="space-y-2">
+              <div className="flex items-center justify-between">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-4 w-32" />
+              </div>
+              <Skeleton className="h-3 w-full rounded-full" />
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="opacity-0 animate-fade-in-up">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">今日のPFCバランス</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">PFCデータの取得に失敗しました</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Card className="opacity-0 animate-fade-in-up">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg">今日のPFCバランス</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            食事を記録するとPFCバランスが表示されます
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="opacity-0 animate-fade-in-up">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">今日のPFCバランス</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {NUTRIENT_CONFIGS.map((config) => (
+          <NutrientProgressBar
+            key={config.key}
+            config={config}
+            current={data.current[config.key]}
+            target={data.target[config.key]}
+          />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/features/nutrition/components/index.ts
+++ b/frontend/src/features/nutrition/components/index.ts
@@ -3,3 +3,6 @@
  */
 export { NutritionAdviceCard } from "./NutritionAdviceCard";
 export type { NutritionAdviceCardProps } from "./NutritionAdviceCard";
+
+export { PfcProgressCard } from "./PfcProgressCard";
+export type { PfcProgressCardProps } from "./PfcProgressCard";

--- a/frontend/src/features/nutrition/hooks/index.ts
+++ b/frontend/src/features/nutrition/hooks/index.ts
@@ -6,3 +6,10 @@ export {
   ERROR_MESSAGE_FETCH_FAILED,
   type NutritionAdviceResponse,
 } from "./useNutritionAdvice";
+
+export {
+  useTodayPfc,
+  ERROR_MESSAGE_PFC_FETCH_FAILED,
+  type TodayPfcResponse,
+  type PfcValues,
+} from "./useTodayPfc";

--- a/frontend/src/features/nutrition/hooks/useTodayPfc.test.ts
+++ b/frontend/src/features/nutrition/hooks/useTodayPfc.test.ts
@@ -1,0 +1,30 @@
+/**
+ * useTodayPfc フックのテスト
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTodayPfc, ERROR_MESSAGE_PFC_FETCH_FAILED } from "./useTodayPfc";
+
+vi.mock("@/features/common/hooks", () => ({
+  useRequestGet: vi.fn(() => {
+    return { data: undefined, error: null, isLoading: true, isValidating: false, mutate: vi.fn() };
+  }),
+}));
+
+describe("useTodayPfc", () => {
+  it("初期状態ではローディング中となる", () => {
+    const { result } = renderHook(() => useTodayPfc());
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("refetch関数が返される", () => {
+    const { result } = renderHook(() => useTodayPfc());
+    expect(typeof result.current.refetch).toBe("function");
+  });
+
+  it("ERROR_MESSAGE_PFC_FETCH_FAILEDが正しい", () => {
+    expect(ERROR_MESSAGE_PFC_FETCH_FAILED).toBe("PFCデータの取得に失敗しました");
+  });
+});

--- a/frontend/src/features/nutrition/hooks/useTodayPfc.ts
+++ b/frontend/src/features/nutrition/hooks/useTodayPfc.ts
@@ -1,0 +1,32 @@
+/**
+ * useTodayPfc - 今日のPFC摂取量・目標値取得フック
+ */
+import { useRequestGet } from "@/features/common/hooks";
+
+/** PFC栄養素の値 */
+export type PfcValues = {
+  protein: number;
+  fat: number;
+  carbs: number;
+};
+
+/** 今日のPFCレスポンス型 */
+export type TodayPfcResponse = {
+  date: string;
+  current: PfcValues;
+  target: PfcValues;
+};
+
+/** エラーメッセージ */
+export const ERROR_MESSAGE_PFC_FETCH_FAILED = "PFCデータの取得に失敗しました";
+
+/**
+ * 今日のPFC摂取量・目標値を取得するフック
+ * @returns { data, error, isLoading, refetch }
+ */
+export function useTodayPfc() {
+  const { data, error, isLoading, isValidating, mutate } =
+    useRequestGet<TodayPfcResponse>("/api/v1/nutrition/today-pfc");
+
+  return { data, error, isLoading: isLoading || isValidating, refetch: mutate };
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -15,7 +15,7 @@ import {
 import { PeriodSelector } from "@/features/statistics/components/PeriodSelector";
 import { StatisticsCard } from "@/features/statistics/components/StatisticsCard";
 import { CalorieChart } from "@/features/statistics/components/CalorieChart";
-import { useNutritionAdvice, NutritionAdviceCard } from "@/features/nutrition";
+import { useNutritionAdvice, NutritionAdviceCard, useTodayPfc, PfcProgressCard } from "@/features/nutrition";
 
 /**
  * DashboardPage - ダッシュボードページコンポーネント
@@ -35,6 +35,12 @@ export function DashboardPage() {
     isLoading: adviceLoading,
     refetch: adviceRefetch,
   } = useNutritionAdvice();
+  const {
+    data: pfcData,
+    error: pfcError,
+    isLoading: pfcLoading,
+    refetch: pfcRefetch,
+  } = useTodayPfc();
 
   /**
    * 記録成功時のコールバック
@@ -44,6 +50,7 @@ export function DashboardPage() {
     refetch();
     statisticsRefetch();
     adviceRefetch();
+    pfcRefetch();
   };
 
   return (
@@ -58,6 +65,15 @@ export function DashboardPage() {
               <RecordDialog onSuccess={handleRecordSuccess} />
             </div>
             <TodaySummary data={data ?? null} isLoading={isLoading} error={error ?? null} />
+          </section>
+
+          {/* 今日のPFCバランスセクション */}
+          <section>
+            <PfcProgressCard
+              data={pfcData ?? null}
+              isLoading={pfcLoading}
+              error={pfcError ?? null}
+            />
           </section>
 
           {/* PFCアドバイスセクション */}


### PR DESCRIPTION
## Summary
- PfcNutrient VO作成（ラベル情報をドメイン層に集約）
- PfcProgressCard: 進捗率に応じた3段階色変え（normal/optimal/over）と100%超の実%表示
- Progress: indicatorClassName props追加でインジケータ色カスタマイズ対応
- PfcProgressCard Storybook: 7パターン（Default/Optimal/Over/Mixed/Loading/Error/Empty）
- Storybookルール拡充（チェックリスト・テンプレート・title命名規則）

## Test plan
- [ ] `npm run build` でビルド成功
- [ ] `npm run test` で全テストパス（468テスト）
- [ ] `npm run lint` でLintエラーなし
- [ ] Storybookで7パターンの表示確認
- [ ] 進捗率0-79%: デフォルト色（青/黄/緑）表示
- [ ] 進捗率80-100%: 緑色（optimal）表示
- [ ] 進捗率100%超: 赤色（over）+ 実際の%表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)