### PR TITLE
fix(domain): MealType/TimeContextの食事タイプ判定をJST基準に修正

### DIFF
--- a/backend/domain/helper/timezone.go
+++ b/backend/domain/helper/timezone.go
@@ -1,0 +1,11 @@
+package helper
+
+import "time"
+
+// jst は日本標準時（UTC+9）のロケーション
+var jst = time.FixedZone("Asia/Tokyo", 9*60*60)
+
+// JST は日本標準時の *time.Location を返す
+func JST() *time.Location {
+	return jst
+}

--- a/backend/domain/helper/timezone_test.go
+++ b/backend/domain/helper/timezone_test.go
@@ -1,0 +1,41 @@
+package helper
+
+import (
+	"testing"
+	"time"
+)
+
+func TestJST(t *testing.T) {
+	loc := JST()
+
+	t.Run("nilでないこと", func(t *testing.T) {
+		if loc == nil {
+			t.Fatal("JST() returned nil")
+		}
+	})
+
+	t.Run("タイムゾーン名がAsia/Tokyoであること", func(t *testing.T) {
+		if loc.String() != "Asia/Tokyo" {
+			t.Errorf("JST().String() = %q, want %q", loc.String(), "Asia/Tokyo")
+		}
+	})
+
+	t.Run("UTCからのオフセットが+9時間であること", func(t *testing.T) {
+		utcTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		jstTime := utcTime.In(loc)
+
+		_, offset := jstTime.Zone()
+		wantOffset := 9 * 60 * 60
+		if offset != wantOffset {
+			t.Errorf("JST offset = %d, want %d", offset, wantOffset)
+		}
+	})
+
+	t.Run("同一インスタンスを返すこと", func(t *testing.T) {
+		loc1 := JST()
+		loc2 := JST()
+		if loc1 != loc2 {
+			t.Error("JST() should return the same instance")
+		}
+	})
+}

--- a/backend/domain/vo/eaten_at.go
+++ b/backend/domain/vo/eaten_at.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	domainErrors "caltrack/domain/errors"
+	"caltrack/domain/helper"
 )
 
 // MealType は食事タイプを表す
@@ -66,9 +67,14 @@ func (e EatenAt) Equals(other EatenAt) bool {
 	return e.value.Equal(other.value)
 }
 
+// localHour はJSTでの時(hour)を返す
+func (e EatenAt) localHour() int {
+	return e.value.In(helper.JST()).Hour()
+}
+
 // MealType は食事日時から食事タイプを判定して返す
 func (e EatenAt) MealType() MealType {
-	hour := e.value.Hour()
+	hour := e.localHour()
 
 	switch {
 	case hour >= 5 && hour < 11:
@@ -86,7 +92,7 @@ func (e EatenAt) MealType() MealType {
 
 // TimeContext は食事日時からAIアドバイス向けの時間帯コンテキスト文字列を返す
 func (e EatenAt) TimeContext() string {
-	hour := e.value.Hour()
+	hour := e.localHour()
 	mealType := e.MealType()
 
 	switch mealType {

--- a/backend/usecase/helper.go
+++ b/backend/usecase/helper.go
@@ -1,9 +1,14 @@
 package usecase
 
-import "time"
+import (
+	"time"
+
+	"caltrack/domain/helper"
+)
 
 func startOfDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+	jstTime := t.In(helper.JST())
+	return time.Date(jstTime.Year(), jstTime.Month(), jstTime.Day(), 0, 0, 0, 0, helper.JST())
 }
 
 func endOfDay(t time.Time) time.Time {


### PR DESCRIPTION
## Summary
- GetAdvice機能で食事タイプが全て朝食扱いになるバグを修正
- `eaten_at.go` の `MealType()` / `TimeContext()` がUTC時刻をそのまま使っていたため、JST 14時〜20時の食事がUTC 5時〜11時と判定され朝食扱いになっていた
- `domain/helper/timezone.go` を新規作成し、JSTヘルパー関数を追加（`time.FixedZone` 使用、Docker tzdata不要）
- `eaten_at.go` に `localHour()` メソッドを追加し、MealType/TimeContextでJST基準の判定を実施
- `usecase/helper.go` の `startOfDay` もJST基準に変更
- テストデータをJST基準に変更し、境界値テストを追加

## Test plan
- [x] Build: Pass
- [x] Test: Pass (backend全テスト)

🤖 Generated with [Claude Code](https://claude.com/claude-code)