### PR TITLE
fix(ci): npm rebuild追加でrollupネイティブモジュール解決

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Rebuild native modules
+        run: npm rebuild
+
       - name: Build frontend
         env:
           VITE_API_URL: https://caltracks.win


### PR DESCRIPTION
## Summary
- npm workspacesの既知バグ(npm/cli#4828)により、rollupのプラットフォーム固有バイナリ(@rollup/rollup-linux-x64-gnu)がCI環境でインストールされない問題を修正
- `npm ci` 後に `npm rebuild` を実行するステップを追加

## Test plan
- [ ] mainマージ後のCIでfrontendビルド成功を確認

Refs #252

Generated with [Claude Code](https://claude.com/claude-code)