### PR TITLE
fix(ci): frontendを独立してビルドするよう修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,16 +16,13 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Rebuild native modules
-        run: npm rebuild
-
       - name: Build frontend
         env:
           VITE_API_URL: https://caltracks.win
-        run: npm run build --workspace=frontend
+        run: |
+          cd frontend
+          npm ci
+          npm run build
 
       - name: Deploy to Lightsail
         run: |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@caltrack/shared": "*",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-progress": "^1.1.8",


### PR DESCRIPTION
## Summary
- npm workspacesのoptional dependenciesバグによりrollupネイティブモジュールがCI環境で解決できない問題を修正
- CIではfrontendディレクトリ内で独立して`npm ci && npm run build`を実行する元の方式に戻す
- frontend/package.jsonから未使用の`@caltrack/shared`依存を削除（shared参照コードがまだ無いため）

## Test plan
- [x] frontend/package.jsonから@caltrack/shared削除確認
- [ ] mainマージ後のCIでfrontendビルド成功を確認

Refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)